### PR TITLE
Suppress warning messages on empty forms

### DIFF
--- a/lang/en.inc.php
+++ b/lang/en.inc.php
@@ -110,5 +110,9 @@ $messages['menutoken'] = "Email";
 $messages['menusms'] = "SMS";
 $messages['nophpxml'] = "You should install PHP XML to use this tool";
 $messages['tokenattempts'] = "Invalid token, try again";
+$messages['emptychangeform'] = "Change your password";
+$messages['emptysendtokenform'] = "Email a password reset link";
+$messages['emptyresetbyquestionsform'] = "Reset your password";
+$messages['emptysetquestionsform'] = "Set your password reset questions";
 
 ?>

--- a/pages/change.php
+++ b/pages/change.php
@@ -43,6 +43,8 @@ if (isset($_POST["oldpassword"]) and $_POST["oldpassword"]) { $oldpassword = $_P
  else { $result = "oldpasswordrequired"; }
 if (isset($_REQUEST["login"]) and $_REQUEST["login"]) { $login = $_REQUEST["login"]; }
  else { $result = "loginrequired"; }
+if (! isset($_REQUEST["login"]) and ! isset($_POST["confirmpassword"]) and ! isset($_POST["newpassword"]) and ! isset($_POST["oldpassword"]))
+ { $result = "emptychangeform"; }
 
 # Strip slashes added by PHP
 $login = stripslashes_if_gpc_magic_quotes($login);

--- a/pages/resetbyquestions.php
+++ b/pages/resetbyquestions.php
@@ -46,6 +46,8 @@ if (isset($_POST["question"]) and $_POST["question"]) { $question = $_POST["ques
  else { $result = "questionrequired"; }
 if (isset($_REQUEST["login"]) and $_REQUEST["login"]) { $login = $_REQUEST["login"]; }
  else { $result = "loginrequired"; }
+if (! isset($_POST["confirmpassword"]) and ! isset($_POST["newpassword"]) and ! isset($_POST["answer"]) and ! isset($_POST["question"]) and ! isset($_REQUEST["login"]))
+ { $result = "emptyresetbyquestionsform"; }
 
 # Strip slashes added by PHP
 $login = stripslashes_if_gpc_magic_quotes($login);

--- a/pages/sendtoken.php
+++ b/pages/sendtoken.php
@@ -36,6 +36,8 @@ if (isset($_POST["mail"]) and $_POST["mail"]) { $mail = $_POST["mail"]; }
  else { $result = "mailrequired"; }
 if (isset($_REQUEST["login"]) and $_REQUEST["login"]) { $login = $_REQUEST["login"]; }
  else { $result = "loginrequired"; }
+if (! isset($_POST["mail"]) and ! isset($_REQUEST["login"]))
+ { $result = "emptysendtokenform"; }
 
 # Strip slashes added by PHP
 $login = stripslashes_if_gpc_magic_quotes($login);

--- a/pages/setquestions.php
+++ b/pages/setquestions.php
@@ -41,6 +41,8 @@ if (isset($_POST["password"]) and $_POST["password"]) { $password = $_POST["pass
  else { $result = "passwordrequired"; }
 if (isset($_REQUEST["login"]) and $_REQUEST["login"]) { $login = $_REQUEST["login"]; }
  else { $result = "loginrequired"; }
+if (! isset($_POST["answer"]) and ! isset($_POST["question"]) and ! isset($_POST["password"]) and ! isset($_REQUEST["login"]))
+ { $result = "emptysetquestionsform"; }
 
 # Strip slashes added by PHP
 $login = stripslashes_if_gpc_magic_quotes($login);


### PR DESCRIPTION
Currently, the logic in SSP results in every page, when first displayed to the user, showing an error message of "Your login is required". This is a poor user experience and a bit confusing. Before a user attempts to fill in a form, they should not see an error message.

I've put together a fix for this which does the following :
* After all of the POST/GET parameters are validated on the various pages (`change.php`, `setquestions.php`, etc), a final check is done which checks to see if *all* expected fields are not set `(! isset())`. If *all* fields are unset, we don't need to show the user an error message saying that the fields are empty, instead display a title in the `$result` div.
* Set `$result` to a new message that merely explains what the page is.
* Add in the 4 title messages to the localizations (currently I've filled in English)

This will be a much better experience than having a red warning message with a triangle exclamation point icon *every* time a user uses any page in SSP.

http://tools.lsc-project.org/issues/400
Fixes Issue #35 
Originally from [this patch](http://tools.lsc-project.org/attachments/322/ssp-issue-400.patch)