### PR TITLE
Escape shell args with escapeshellarg for posthook command (fixes #33)

### DIFF
--- a/pages/change.php
+++ b/pages/change.php
@@ -187,7 +187,8 @@ if ( $result === "" ) {
 if ( $result === "" ) {
     $result = change_password($ldap, $userdn, $newpassword, $ad_mode, $ad_options, $samba_mode, $samba_options, $shadow_options, $hash, $hash_options, $who_change_password, $oldpassword);
     if ( $result === "passwordchanged" && isset($posthook) ) {
-        exec(escapeshellcmd("$posthook $login $newpassword $oldpassword"));
+        $command = escapeshellcmd($posthook).' '.escapeshellarg($login).' '.escapeshellarg($newpassword).' '.escapeshellarg($oldpassword);
+        exec($command);
     }
 }
 

--- a/pages/resetbyquestions.php
+++ b/pages/resetbyquestions.php
@@ -179,7 +179,8 @@ if ( $result === "" ) {
 if ($result === "") {
     $result = change_password($ldap, $userdn, $newpassword, $ad_mode, $ad_options, $samba_mode, $samba_options, $shadow_options, $hash, $hash_options, "", "");
     if ( $result === "passwordchanged" && isset($posthook) ) {
-        exec(escapeshellcmd("$posthook $login $newpassword"));
+        $command = escapeshellcmd($posthook).' '.escapeshellarg($login).' '.escapeshellarg($newpassword);
+        exec($command);
     }
 }
 

--- a/pages/resetbytoken.php
+++ b/pages/resetbytoken.php
@@ -198,7 +198,8 @@ if ( $result === "" ) {
 if ($result === "") {
     $result = change_password($ldap, $userdn, $newpassword, $ad_mode, $ad_options, $samba_mode, $samba_options, $shadow_options, $hash, $hash_options, "", "");
     if ( $result === "passwordchanged" && isset($posthook) ) {
-        exec(escapeshellcmd("$posthook $login $newpassword"));
+        $command = escapeshellcmd($posthook).' '.escapeshellarg($login).' '.escapeshellarg($newpassword);
+        exec($command);
     }
 }
 


### PR DESCRIPTION
There is indeed a bug, if the new or old password contains spaces, ' or ", the posthook can fail or be called with bad arguments.

This change is based on OP [original patch](http://tools.ltb-project.org/issues/844) for the issue and applied to all places where the posthook can be called.
