### PR TITLE
Mail use fullname

### DIFF
--- a/conf/config.inc.php
+++ b/conf/config.inc.php
@@ -30,6 +30,7 @@ $ldap_bindpw = "secret";
 $ldap_base = "dc=example,dc=com";
 $ldap_login_attribute = "uid";
 $ldap_fullname_attribute = "cn";
+$ldap_givenname_attribue = "givenName";
 $ldap_filter = "(&(objectClass=person)($ldap_login_attribute={login}))";
 
 # Active Directory mode
@@ -154,6 +155,11 @@ $mail_address_use_ldap = false;
 $mail_from = "admin@example.com";
 $mail_from_name = "Self Service Password";
 $mail_signature = "";
+# Which Anrede is used in mails?
+# login (default)
+# fullname
+# givenname
+$mail_display_name = "login";
 # Notify users anytime their password is changed
 $notify_on_change = false;
 # PHPMailer configuration (see https://github.com/PHPMailer/PHPMailer)

--- a/conf/config.inc.php
+++ b/conf/config.inc.php
@@ -155,7 +155,7 @@ $mail_address_use_ldap = false;
 $mail_from = "admin@example.com";
 $mail_from_name = "Self Service Password";
 $mail_signature = "";
-# Which Anrede is used in mails?
+# Which display name is used in mails?
 # login (default)
 # fullname
 # givenname

--- a/pages/change.php
+++ b/pages/change.php
@@ -32,6 +32,7 @@ $newpassword = "";
 $oldpassword = "";
 $ldap = "";
 $userdn = "";
+$display_name_lookup = "";
 if (!isset($pwd_forbidden_chars)) { $pwd_forbidden_chars=""; }
 $mail = "";
 
@@ -129,6 +130,9 @@ if ( $result === "" ) {
         if ( $mailValues["count"] > 0 ) {
             $mail = $mailValues[0];
         }
+        $display_name_lookup["login"] = ldap_get_values($ldap, $entry, $ldap_login_attribute);
+        $display_name_lookup["givenname"] = ldap_get_values($ldap, $entry, $ldap_givenname_attribute);
+        $display_name_lookup["fullname"] = ldap_get_values($ldap, $entry, $ldap_fullname_attribute);       
     }
 
     # Check objectClass to allow samba and shadow updates
@@ -302,7 +306,7 @@ if ($pwd_show_policy_pos === 'below') {
 
     # Notify password change
     if ($mail and $notify_on_change) {
-        $data = array( "login" => $login, "mail" => $mail, "password" => $newpassword);
+        $data = array( "login" => $display_name_lookup[$mail_display_name], "mail" => $mail, "password" => $newpassword);
         if ( !send_mail($mailer, $mail, $mail_from, $mail_from_name, $messages["changesubject"], $messages["changemessage"].$mail_signature, $data) ) {
             error_log("Error while sending change email to $mail (user $login)");
         }

--- a/pages/resetbyquestions.php
+++ b/pages/resetbyquestions.php
@@ -33,6 +33,7 @@ $newpassword = "";
 $confirmpassword = "";
 $ldap = "";
 $userdn = "";
+$display_name_lookup = "";
 if (!isset($pwd_forbidden_chars)) { $pwd_forbidden_chars=""; }
 $mail = "";
 
@@ -140,6 +141,9 @@ if ( $result === "" ) {
         if ( $mailValues["count"] > 0 ) {
             $mail = $mailValues[0];
         }
+        $display_name_lookup["login"] = ldap_get_values($ldap, $entry, $ldap_login_attribute);
+        $display_name_lookup["givenname"] = ldap_get_values($ldap, $entry, $ldap_givenname_attribute);
+        $display_name_lookup["fullname"] = ldap_get_values($ldap, $entry, $ldap_fullname_attribute); 
     } 
 
     # Get question/answer values
@@ -292,7 +296,7 @@ if ($pwd_show_policy_pos === 'below') {
 
     # Notify password change
     if ($mail and $notify_on_change) {
-        $data = array( "login" => $login, "mail" => $mail, "password" => $newpassword);
+        $data = array( "login" => $display_name_lookup[$mail_display_name], "mail" => $mail, "password" => $newpassword);
         if ( !send_mail($mailer, $mail, $mail_from, $mail_from_name, $messages["changesubject"], $messages["changemessage"].$mail_signature, $data) ) {
             error_log("Error while sending change email to $mail (user $login)");
         }

--- a/pages/resetbytoken.php
+++ b/pages/resetbytoken.php
@@ -33,6 +33,8 @@ $newpassword = "";
 $confirmpassword = "";
 $ldap = "";
 $userdn = "";
+$display_name_lookup = "";
+
 if (!isset($pwd_forbidden_chars)) { $pwd_forbidden_chars=""; }
 $mail = "";
 $source = "";
@@ -177,6 +179,9 @@ if ( $result === "" ) {
         if ( $mailValues["count"] > 0 ) {
             $mail = $mailValues[0];
         }
+        $$display_name_lookup["login"] = ldap_get_values($ldap, $entry, $ldap_login_attribute);
+        $display_name_lookup["givenname"] = ldap_get_values($ldap, $entry, $ldap_givenname_attribute);
+        $display_name_lookup["fullname"] = ldap_get_values($ldap, $entry, $ldap_fullname_attribute); 
     }
 
 }}}}
@@ -302,7 +307,7 @@ if ($pwd_show_policy_pos === 'below') {
 
     # Notify password change
     if ($mail and $notify_on_change) {
-        $data = array( "login" => $login, "mail" => $mail, "password" => $newpassword);
+        $data = array( "login" => $display_name_lookup[$mail_display_name], "mail" => $mail, "password" => $newpassword);
         if ( !send_mail($mailer, $mail, $mail_from, $mail_from_name, $messages["changesubject"], $messages["changemessage"].$mail_signature, $data) ) {
             error_log("Error while sending change email to $mail (user $login)");
         }

--- a/pages/sendtoken.php
+++ b/pages/sendtoken.php
@@ -31,6 +31,7 @@ $mail = "";
 $ldap = "";
 $userdn = "";
 $token = "";
+$display_name_lookup = "";
 
 if (!$mail_address_use_ldap) {
     if (isset($_POST["mail"]) and $_POST["mail"]) { $mail = $_POST["mail"]; }
@@ -140,6 +141,10 @@ if ( $result === "" ) {
         }
     }
 
+    $display_name_lookup["login"] = ldap_get_values($ldap, $entry, $ldap_login_attribute);
+    $display_name_lookup["givenname"] = ldap_get_values($ldap, $entry, $ldap_givenname_attribute);
+    $display_name_lookup["fullname"] = ldap_get_values($ldap, $entry, $ldap_fullname_attribute); 
+
     if (!$match) {
         if (!$mail_address_use_ldap) {
             $result = "mailnomatch";
@@ -207,7 +212,7 @@ if ( $result === "" ) {
         error_log("Send reset URL $reset_url");
     }
 
-    $data = array( "login" => $login, "mail" => $mail, "url" => $reset_url ) ;
+    $data = array( "login" => $display_name_lookup[$mail_display_name], "mail" => $mail, "url" => $reset_url ) ;
 
     # Send message
     if ( send_mail($mailer, $mail, $mail_from, $mail_from_name, $messages["resetsubject"], $messages["resetmessage"].$mail_signature, $data) ) {


### PR DESCRIPTION
I wrote this because I wanted my emails to look more pretty by displaying the fullname of a user instead of the username/login. Instead of "jsmith92" you can also use "Jones Smith" or just "Jones". Default option is still the login name.