### PR TITLE
Copying configuration file is now required

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+config/config.inc.php

--- a/conf/config.inc-sample.php
+++ b/conf/config.inc-sample.php
@@ -253,4 +253,3 @@ $default_action = "change";
 # Launch a posthook script after successful password change
 #$posthook = "/usr/share/self-service-password/posthook.sh";
 
-?>

--- a/index.php
+++ b/index.php
@@ -22,7 +22,9 @@
 #==============================================================================
 # Includes
 #==============================================================================
-require_once("conf/config.inc.php");
+$config_found = (file_exists("conf/config.inc.php"));
+if ($config_found)
+    require_once("conf/config.inc.php");
 require_once("lib/functions.inc.php");
 if ($use_recaptcha) {
     require_once("lib/vendor/autoload.php");
@@ -63,6 +65,9 @@ ini_set('output_buffering', '0');
 #==============================================================================
 # Init dependency check results variable
 $dependency_check_results = array();
+
+# Check config.inc.php presence
+if ( !$config_found ) { $dependency_check_results[] = "noltbconfig"; }
 
 # Check PHP-LDAP presence
 if ( ! function_exists('ldap_connect') ) { $dependency_check_results[] = "nophpldap"; }

--- a/lang/ca.inc.php
+++ b/lang/ca.inc.php
@@ -24,6 +24,7 @@
 #==============================================================================
 # Catalan
 #==============================================================================
+$messages['noltbconfig'] = "You must copy conf/config.inc-sample.php to conf/config.inc.php to configure LTB Self Service Password";
 $messages['nophpldap'] = "Cal instal·lar PHP LDAP per fer servir aquesta eina";
 $messages['nophpmhash'] = "Cal instal·lar PHP mhash per fer servir el mode Samba";
 $messages['ldaperror'] = "No es pot accedir al servidor LDAP";

--- a/lang/cn.inc.php
+++ b/lang/cn.inc.php
@@ -22,6 +22,7 @@
 #==============================================================================
 # English
 #==============================================================================
+$messages['noltbconfig'] = "You must copy conf/config.inc-sample.php to conf/config.inc.php to configure LTB Self Service Password";
 $messages['nophpldap'] = "使用该工具需要安装PHP-Ldap";
 $messages['nophpmhash'] = "使用Samba模式需要安装PHP mhash";
 $messages['ldaperror'] = "无法访问LDAP目录";

--- a/lang/cs.inc.php
+++ b/lang/cs.inc.php
@@ -22,6 +22,7 @@
 #==============================================================================
 # Czech
 #==============================================================================
+$messages['noltbconfig'] = "You must copy conf/config.inc-sample.php to conf/config.inc.php to configure LTB Self Service Password";
 $messages['nophpldap'] = "Nainstalujte PHP LDAP pro použití tohoto nástroje";
 $messages['nophpmhash'] = "Nainstalujte PHP mhash k použití módu Samba";
 $messages['ldaperror'] = "Nelze přistoupit k LDAP adresáři";

--- a/lang/de.inc.php
+++ b/lang/de.inc.php
@@ -22,6 +22,7 @@
 #==============================================================================
 # German
 #==============================================================================
+$messages['noltbconfig'] = "You must copy conf/config.inc-sample.php to conf/config.inc.php to configure LTB Self Service Password";
 $messages['nophpldap'] = "Sie benötigen die PHP LDAP Erweiterung um dieses Tool zu nutzen";
 $messages['nophpmhash'] = "Sie benötigen die PHP mhash Erweiterung um den Samba Modus zu nutzen";
 $messages['ldaperror'] = "Kein Zugriff auf das LDAP möglich";

--- a/lang/el.inc.php
+++ b/lang/el.inc.php
@@ -22,6 +22,7 @@
 #==============================================================================
 # Greek
 #==============================================================================
+$messages['noltbconfig'] = "You must copy conf/config.inc-sample.php to conf/config.inc.php to configure LTB Self Service Password";
 $messages['nophpldap'] = "Απαιτείται η εγκατάσταση του πρόσθετου PHP LDAP για τη λειτουργία αυτής της εφαρμογής";
 $messages['nophpmhash'] = "Απαιτείται η εγκατάσταση του πρόσθετου PHP mhash για τη χρήση Samba";
 $messages['ldaperror'] = "Αδυναμία πρόσβασης στην υπηρεσία καταλόγου";

--- a/lang/en.inc.php
+++ b/lang/en.inc.php
@@ -22,6 +22,7 @@
 #==============================================================================
 # English
 #==============================================================================
+$messages['noltbconfig'] = "You must copy conf/config.inc-sample.php to conf/config.inc.php to configure LTB Self Service Password";
 $messages['nophpldap'] = "You should install PHP LDAP to use this tool";
 $messages['nophpmhash'] = "You should install PHP mhash to use Samba mode";
 $messages['ldaperror'] = "Cannot access LDAP directory";

--- a/lang/es.inc.php
+++ b/lang/es.inc.php
@@ -22,6 +22,7 @@
 #==============================================================================
 # Spanish
 #==============================================================================
+$messages['noltbconfig'] = "You must copy conf/config.inc-sample.php to conf/config.inc.php to configure LTB Self Service Password";
 $messages['nophpldap'] = "Debe instalar PHP LDAP para utilizar esta herramienta";
 $messages['nophpmhash'] = "Debe instalar PHP mhash para utilizar el modo Samba";
 $messages['ldaperror'] = "No es posible acceder al directorio LDAP";

--- a/lang/fr.inc.php
+++ b/lang/fr.inc.php
@@ -22,6 +22,7 @@
 #==============================================================================
 # French
 #==============================================================================
+$messages['noltbconfig'] = "You must copy conf/config.inc-sample.php to conf/config.inc.php to configure LTB Self Service Password";
 $messages['nophpldap'] = "Vous devriez installer PHP LDAP pour utiliser cet outil";
 $messages['nophpmhash'] = "Vous devriez installer PHP mhash pour utiliser le mode Samba";
 $messages['ldaperror'] = "Erreur d'acc&egrave;s &agrave; l'annuaire";

--- a/lang/hu.inc.php
+++ b/lang/hu.inc.php
@@ -22,6 +22,7 @@
 #==============================================================================
 # Hungarian
 #==============================================================================
+$messages['noltbconfig'] = "You must copy conf/config.inc-sample.php to conf/config.inc.php to configure LTB Self Service Password";
 $messages['nophpldap'] = "A program használatához telepíteni kell a PHP LDAP csomagot";
 $messages['nophpmhash'] = "A Samba üzemmód használatához telepíteni kell a PHP mhash csomagot";
 $messages['ldaperror'] = "Nem érhető el az LDAP szolgáltatás";

--- a/lang/it.inc.php
+++ b/lang/it.inc.php
@@ -22,6 +22,7 @@
 #==============================================================================
 # Italian
 #==============================================================================
+$messages['noltbconfig'] = "You must copy conf/config.inc-sample.php to conf/config.inc.php to configure LTB Self Service Password";
 $messages['nophpldap'] = "Devi installare PHP LDAP per usare questo strumento";
 $messages['nophpmhash'] = "Devi installare PHP mhash per usare il modo Samba";
 $messages['ldaperror'] = "Non posso accedere alla directory LDAP";

--- a/lang/ja.inc.php
+++ b/lang/ja.inc.php
@@ -22,6 +22,7 @@
 #==============================================================================
 # Japanese
 #==============================================================================
+$messages['noltbconfig'] = "You must copy conf/config.inc-sample.php to conf/config.inc.php to configure LTB Self Service Password";
 $messages['nophpldap'] = "このツールを使うにはPHP LDAPをインストールしてください";
 $messages['nophpmhash'] = "Sambaモードを使うにはPHP mhashをインストールしてください";
 $messages['ldaperror'] = "LDAPディレクトリーにアクセスできません";

--- a/lang/nl.inc.php
+++ b/lang/nl.inc.php
@@ -22,6 +22,7 @@
 #==============================================================================
 # Dutch
 #==============================================================================
+$messages['noltbconfig'] = "You must copy conf/config.inc-sample.php to conf/config.inc.php to configure LTB Self Service Password";
 $messages['nophpldap'] = "PHP LDAP moet geinstalleerd zijn om deze tool te kunnen gebruiken";
 $messages['nophpmhash'] = "PHP mhash moet geinstalleerd zijn om Samba mode te kunnen gebruiken";
 $messages['ldaperror'] = "Kan geen toegang tot de LDAP directory verkrijgen";

--- a/lang/pl.inc.php
+++ b/lang/pl.inc.php
@@ -22,6 +22,7 @@
 #==============================================================================
 # Polish
 #==============================================================================
+$messages['noltbconfig'] = "You must copy conf/config.inc-sample.php to conf/config.inc.php to configure LTB Self Service Password";
 $messages['nophpldap'] = "Wymagane jest zainstalowanie PHP-LDAP zanim użyjesz tego narzędzia";
 $messages['nophpmhash'] = "Wymagane jest zainstalowanie PHP-mhash przed użyciem trybu Samba";
 $messages['ldaperror'] = "Nie można połączyć się z bazą LDAP";

--- a/lang/pt-BR.inc.php
+++ b/lang/pt-BR.inc.php
@@ -22,6 +22,7 @@
 #==============================================================================
 # Pt-BR
 #==============================================================================
+$messages['noltbconfig'] = "You must copy conf/config.inc-sample.php to conf/config.inc.php to configure LTB Self Service Password";
 $messages['nophpldap'] = "Você deve instalar o PHP LDAP para utilizar esta ferramenta";
 $messages['nophpmhash'] = "Você deve instalar o PHP mhash para utilizar o Samba mode";
 $messages['ldaperror'] = "Não foi possível acessar o diretório LDAP";

--- a/lang/pt-PT.inc.php
+++ b/lang/pt-PT.inc.php
@@ -22,6 +22,7 @@
 #==============================================================================
 # pt-PT
 #==============================================================================
+$messages['noltbconfig'] = "You must copy conf/config.inc-sample.php to conf/config.inc.php to configure LTB Self Service Password";
 $messages['nophpldap'] = "Necessitas de instalar o PHP LDAP para utilizares esta ferramenta.";
 $messages['nophpmhash'] = "Necessitas de instalar o PHP mhash para utilizares o Samba mode.";
 $messages['ldaperror'] = "Não foi possivel aceder à pasta LDAP.";

--- a/lang/ru.inc.php
+++ b/lang/ru.inc.php
@@ -22,6 +22,7 @@
 #==============================================================================
 # Русский
 #==============================================================================
+$messages['noltbconfig'] = "You must copy conf/config.inc-sample.php to conf/config.inc.php to configure LTB Self Service Password";
 $messages['nophpldap'] = "Для использования данной программы Вам необходимо установить PHP-Ldap";
 $messages['nophpmhash'] = "Для использования Samba mode установите сначала PHP mhash";
 $messages['ldaperror'] = "Нет доступа к LDAP directory";

--- a/lang/sk.inc.php
+++ b/lang/sk.inc.php
@@ -22,6 +22,7 @@
 #==============================================================================
 # Slovak
 #==============================================================================
+$messages['noltbconfig'] = "You must copy conf/config.inc-sample.php to conf/config.inc.php to configure LTB Self Service Password";
 $messages['nophpldap'] = "Mali by ste nainštalovať PHP LDAP";
 $messages['nophpmhash'] = "Mali by ste nainštalovať PHP mhash pri používaní Samba režimu";
 $messages['ldaperror'] = "Nemožno získať prístup k adresáru LDAP";

--- a/lang/sl.inc.php
+++ b/lang/sl.inc.php
@@ -22,6 +22,7 @@
 #==============================================================================
 # Slovenian
 #==============================================================================
+$messages['noltbconfig'] = "You must copy conf/config.inc-sample.php to conf/config.inc.php to configure LTB Self Service Password";
 $messages['nophpldap'] = "Namestiti morate PHP LDAP";
 $messages['nophpmhash'] = "Za način Samba morate namestiti PHP mhash";
 $messages['ldaperror'] = "Dostop do LDAP ni mogoč";

--- a/lang/sv.inc.php
+++ b/lang/sv.inc.php
@@ -22,6 +22,7 @@
 #==============================================================================
 # Swedish
 #==============================================================================
+$messages['noltbconfig'] = "You must copy conf/config.inc-sample.php to conf/config.inc.php to configure LTB Self Service Password";
 $messages['nophpldap'] = "Du borde installera PHP LDAP för att använda detta verktyg";
 $messages['nophpmhash'] = "Du borde installera PHP mhash för att använda Samba mode";
 $messages['ldaperror'] = "Kan inte komma åt LDAPkatalogen";

--- a/lang/tr.inc.php
+++ b/lang/tr.inc.php
@@ -22,6 +22,7 @@
 #==============================================================================
 # Turkish
 #==============================================================================
+$messages['noltbconfig'] = "You must copy conf/config.inc-sample.php to conf/config.inc.php to configure LTB Self Service Password";
 $messages['nophpldap'] = "Bu aracı kullanabilmek için PHP LDAP yüklemelisiniz";
 $messages['nophpmhash'] = "Samba modunu kullanmak için PHP mhash yüklemelisiniz";
 $messages['ldaperror'] = "LDAP dizinine ulaşılamıyor";

--- a/lang/uk.inc.php
+++ b/lang/uk.inc.php
@@ -23,6 +23,7 @@
 #==============================================================================
 # Український
 #==============================================================================
+$messages['noltbconfig'] = "You must copy conf/config.inc-sample.php to conf/config.inc.php to configure LTB Self Service Password";
 $messages['nophpldap'] = "Для використання цієї програми Вам потрібно встановити PHP ldap";
 $messages['nophpmhash'] = "Для використання Samba режиму, спочатку встановіть PHP mhash";
 $messages['ldaperror'] = "Немає доступу до LDAP директорії";

--- a/lang/zh-CN.inc.php
+++ b/lang/zh-CN.inc.php
@@ -22,6 +22,7 @@
 #==============================================================================
 # Simplified Chinese
 #==============================================================================
+$messages['noltbconfig'] = "You must copy conf/config.inc-sample.php to conf/config.inc.php to configure LTB Self Service Password";
 $messages['nophpldap'] = "您需要安装PHP LDAP才能使用本工具";
 $messages['nophpmhash'] = "您需要安装PHP mhash才能使用Samba模式";
 $messages['ldaperror'] = "不能访问LDAP服务器";

--- a/lib/functions.inc.php
+++ b/lib/functions.inc.php
@@ -119,7 +119,7 @@ function stripslashes_if_gpc_magic_quotes( $string ) {
 # Get message criticity
 function get_criticity( $msg ) {
 
-    if ( preg_match( "/nophpldap|nophpmhash|ldaperror|nomatch|badcredentials|passworderror|tooshort|toobig|minlower|minupper|mindigit|minspecial|forbiddenchars|sameasold|answermoderror|answernomatch|mailnomatch|tokennotsent|tokennotvalid|notcomplex|nophpmcrypt|smsnonumber|smscrypttokensrequired|nophpmbstring|nophpxml|smsnotsent|sameaslogin/" , $msg ) ) {
+    if ( preg_match( "/nophpldap|nophpmhash|ldaperror|nomatch|badcredentials|passworderror|tooshort|toobig|minlower|minupper|mindigit|minspecial|forbiddenchars|sameasold|answermoderror|answernomatch|mailnomatch|tokennotsent|tokennotvalid|notcomplex|nophpmcrypt|smsnonumber|smscrypttokensrequired|nophpmbstring|nophpxml|smsnotsent|sameaslogin|noltbconfig/" , $msg ) ) {
     return "danger";
     }
 	


### PR DESCRIPTION
To avoid accidental commits of the configuration file, it was
removed in favour of a sample config file which needs to be copied
to be used as default.