### PR TITLE
Enable credential-free deployment

### DIFF
--- a/conf/config.inc.php
+++ b/conf/config.inc.php
@@ -31,6 +31,8 @@ $ldap_base = "dc=example,dc=com";
 $ldap_login_attribute = "uid";
 $ldap_fullname_attribute = "cn";
 $ldap_filter = "(&(objectClass=person)($ldap_login_attribute={login}))";
+# DN that is the parent of all users
+$ldap_userparentdn = "cn=Users,dc=example,dc=com";
 
 # Active Directory mode
 # true: use unicodePwd as password field

--- a/pages/change.php
+++ b/pages/change.php
@@ -94,6 +94,9 @@ if ( $result === "" ) {
     # Bind
     if ( isset($ldap_binddn) && isset($ldap_bindpw) ) {
         $bind = ldap_bind($ldap, $ldap_binddn, $ldap_bindpw);
+    } else if ( $who_change_password == "user" && isset($ldap_login_attribute) && isset($ldap_userparentdn) ) {
+        $login_dn = $ldap_login_attribute . "=" . $login . "," . $ldap_userparentdn;
+        $bind = ldap_bind($ldap, $login_dn, $oldpassword);
     } else {
         $bind = ldap_bind($ldap);
     }


### PR DESCRIPTION
In my environment I would like to be able to deploy Self Service Password without storing any LDAP credentials on the box where it's running, and I realized that in many cases the user's own credentials should be enough. This modifies the tool so that `ldap_binddn` and `ldap_bindpw` can be left unset. Just thought I would share this in case you think it would be useful to others. Thanks for a great tool!