### PR TITLE
Force use of phpunit 5.7 if php >= 7.0 for travis testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,13 @@ php:
   - '5.4'
   - '5.5'
   - '5.6'
+  - '7.0'
+  - '7.1'
   - hhvm
+
+before_install:
+  # If PHP >= 7.0, force use of PHPUnit 5.7
+  - if php -r "exit( (int)! version_compare( '$TRAVIS_PHP_VERSION', '7.0', '>=' ) );"; then mkdir ~/bin && wget -O ~/bin/phpunit https://phar.phpunit.de/phpunit-5.7.phar && chmod +x ~/bin/phpunit; fi
 
 script: phpunit tests
 


### PR DESCRIPTION
Solves https://github.com/ltb-project/self-service-password/issues/87

Also add testing on php 7.1

Solution found in mantisbt
https://github.com/mantisbt/mantisbt/blob/master/.travis.yml