### PR TITLE
Feature check password history

### DIFF
--- a/conf/config.inc.php
+++ b/conf/config.inc.php
@@ -75,6 +75,11 @@ $hash = "clear";
 $hash_options['crypt_salt_prefix'] = "$6$";
 $hash_options['crypt_salt_length'] = "6";
 
+# Check password history, refuse password change if password is in password history
+$check_password_history = false;
+# Attribute with password history
+$password_history_attribute = "pwdHistory";
+
 # Local password policy
 # This is applied before directory password policy
 # Minimal length

--- a/conf/config.inc.php
+++ b/conf/config.inc.php
@@ -76,9 +76,7 @@ $hash_options['crypt_salt_prefix'] = "$6$";
 $hash_options['crypt_salt_length'] = "6";
 
 # Check password history, refuse password change if password is in password history
-$check_password_history = false;
-# Attribute with password history
-$password_history_attribute = "pwdHistory";
+$ppolicy_options['check_password_history'] = false;
 
 # Local password policy
 # This is applied before directory password policy

--- a/lang/ca.inc.php
+++ b/lang/ca.inc.php
@@ -131,5 +131,6 @@ $messages['menusshkey'] = "claus SSH";
 $messages['changehelpsshkey'] = "<a href=\"?action=changesshkey\">Canviar la clau d'SSH</a>";
 $messages['changesshkeyhelp'] = "Introduïu la contrasenya i la clau SSH.";
 $messages['changesshkeymessage'] = "Hola {login},\n\nLa claus SSH s'ha canviat.\n\nSi no va iniciar aquest canvi, poseu-vos en contacte amb l'administrador immediatament.";
+$messages['passwordused'] = "You already used this password";
 
 ?>

--- a/lang/cn.inc.php
+++ b/lang/cn.inc.php
@@ -127,5 +127,6 @@ $messages['sshkeyerror'] = "LDAP目录拒绝了SSH密钥";
 $messages['sshkeyrequired'] = "需要SSH密钥";
 $messages['changesshkeymessage'] = "您好{login},\n\n您的SSH金钥已变更。\n\n如果您没有启动这项变更，请立即与您的管理员联络。";
 $messages['changesshkeyhelp'] = "输入您的密码和新的SSH密钥。";
+$messages['passwordused'] = "You already used this password";
 
 ?>

--- a/lang/cs.inc.php
+++ b/lang/cs.inc.php
@@ -127,5 +127,6 @@ $messages['sshkeychanged'] = "Váš SSH klíč byl změněn";
 $messages['sshkeyerror'] = "SSH klíč byl odmítnut v adresáři LDAP";
 $messages['sshkey'] = "SSH klíč";
 $messages['menusshkey'] = "SSH klíč";
+$messages['passwordused'] = "You already used this password";
 
 ?>

--- a/lang/de.inc.php
+++ b/lang/de.inc.php
@@ -129,5 +129,6 @@ $messages['emptysshkeychangeform'] = "Ändern Sie Ihren SSH-Schlüssel";
 $messages['changesshkeymessage'] = "Hallo {login}, \n\nDer SSH-Schlüssel wurde geändert.\n\nWenn Sie diese Änderung nicht eingeleitet haben, wenden Sie sich bitte umgehend an Ihren Administrator.";
 $messages['menusshkey'] = "SSH Schlüssel";
 $messages['changesshkeysubject'] = "Ihr SSH-Schlüssel wurde geändert";
+$messages['passwordused'] = "You already used this password";
 
 ?>

--- a/lang/el.inc.php
+++ b/lang/el.inc.php
@@ -127,5 +127,6 @@ $messages['sshkeyrequired'] = "SSH Key απαιτείται";
 $messages['menusshkey'] = "SSH Key";
 $messages['changehelpsshkey'] = "<a href=\"?action=changesshkey\">Αλλάξτε SSH Key σας</a>";
 $messages['sshkey'] = "SSH Key";
+$messages['passwordused'] = "You already used this password";
 
 ?>

--- a/lang/en.inc.php
+++ b/lang/en.inc.php
@@ -127,5 +127,6 @@ $messages['emptysetquestionsform'] = "Set your password reset questions";
 $messages['emptysendsmsform'] = "Get a reset code";
 $messages['sameaslogin'] = "Your new password is identical to your login";
 $messages['policydifflogin'] = "Your new password may not be the same as your login";
+$messages['passwordused'] = "You already used this password";
 
 ?>

--- a/lang/es.inc.php
+++ b/lang/es.inc.php
@@ -128,5 +128,6 @@ $messages['sshkey'] = "Clave SSH";
 $messages['emptysshkeychangeform'] = "Cambiar su clave SSH";
 $messages['changesshkeyhelp'] = "Introduzca su contraseña y la nueva clave SSH.";
 $messages['sshkeyerror'] = "La clave SSH fue rechazada por el directorio LDAP";
+$messages['passwordused'] = "You already used this password";
 
 ?>

--- a/lang/fr.inc.php
+++ b/lang/fr.inc.php
@@ -127,4 +127,6 @@ $messages['sshkey'] = "Clé SSH";
 $messages['emptysshkeychangeform'] = "Changer votre clé SSH";
 $messages['changesshkeyhelp'] = "Entrez votre mot de passe et la nouvelle clé SSH.";
 $messages['sshkeyerror'] = "La clé SSH a été refusée par le répertoire LDAP";
+$messages['passwordused'] = "Le mot de passe a d&eacute;ja &eacute;t&eacute; utilis&eacute;";
+
 ?>

--- a/lang/hu.inc.php
+++ b/lang/hu.inc.php
@@ -127,5 +127,6 @@ $messages['sshkey'] = "SSH kulcs";
 $messages['emptysshkeychangeform'] = "Változás az SSH kulcs";
 $messages['changesshkeyhelp'] = "Írja be a jelszót és az új SSH kulcs.";
 $messages['sshkeyerror'] = "SSH kulcs elutasította az LDAP címtár";
+$messages['passwordused'] = "You already used this password";
 
 ?>

--- a/lang/it.inc.php
+++ b/lang/it.inc.php
@@ -127,4 +127,5 @@ $messages['sshkey'] = "SSH Key";
 $messages['emptysshkeychangeform'] = "Cambia la tua chiave SSH";
 $messages['changesshkeyhelp'] = "Inserire la password e la nuova chiave SSH.";
 $messages['sshkeyerror'] = "SSH Key è stata rifiutata dalla directory LDAP";
+$messages['passwordused'] = "You already used this password";
 ?>

--- a/lang/ja.inc.php
+++ b/lang/ja.inc.php
@@ -127,5 +127,6 @@ $messages['sshkey'] = "SSHキー";
 $messages['emptysshkeychangeform'] = "SSHキーを変更する";
 $messages['changesshkeyhelp'] = "パスワードと新しいSSHキーを入力してください。";
 $messages['sshkeyerror'] = "SSHキーがLDAPディレクトリによって拒否されました";
+$messages['passwordused'] = "You already used this password";
 
 ?>

--- a/lang/nl.inc.php
+++ b/lang/nl.inc.php
@@ -129,5 +129,6 @@ $messages['sshkey'] = "SSH Key";
 $messages['emptysshkeychangeform'] = "Verander je SSH Key";
 $messages['changesshkeyhelp'] = "Voer uw wachtwoord in en nieuwe SSH sleutel.";
 $messages['sshkeyerror'] = "SSH Key werd geweigerd door de LDAP-directory";
+$messages['passwordused'] = "You already used this password";
 
 ?>

--- a/lang/pl.inc.php
+++ b/lang/pl.inc.php
@@ -129,5 +129,6 @@ $messages['sshkey'] = "SSH Key";
 $messages['emptysshkeychangeform'] = "Zmień swój klucz SSH";
 $messages['changesshkeyhelp'] = "Wprowadź swoje hasło i nowy klucz SSH.";
 $messages['sshkeyerror'] = "SSH Key został odrzucony przez katalogu LDAP";
+$messages['passwordused'] = "You already used this password";
 
 ?>

--- a/lang/pt-BR.inc.php
+++ b/lang/pt-BR.inc.php
@@ -127,5 +127,6 @@ $messages['sshkey'] = "Chave SSH";
 $messages['emptysshkeychangeform'] = "Alterar a chave SSH";
 $messages['changesshkeyhelp'] = "Digite sua senha e a nova chave SSH.";
 $messages['sshkeyerror'] = "A chave SSH foi recusada pelo diretório LDAP";
+$messages['passwordused'] = "You already used this password";
 
 ?>

--- a/lang/pt-PT.inc.php
+++ b/lang/pt-PT.inc.php
@@ -127,5 +127,6 @@ $messages['sshkey'] = "Chave SSH";
 $messages['emptysshkeychangeform'] = "Alterar a chave SSH";
 $messages['changesshkeyhelp'] = "Digite sua senha e a nova chave SSH.";
 $messages['sshkeyerror'] = "A chave SSH foi recusada pelo diretório LDAP";
+$messages['passwordused'] = "You already used this password";
 
 ?>

--- a/lang/ru.inc.php
+++ b/lang/ru.inc.php
@@ -127,5 +127,6 @@ $messages['sshkey'] = "Ключ SSH";
 $messages['emptysshkeychangeform'] = "Изменение ключа SSH";
 $messages['changesshkeyhelp'] = "Введите свой пароль и новый ключ SSH.";
 $messages['sshkeyerror'] = "Ключ SSH был отклонен каталогом LDAP";
+$messages['passwordused'] = "You already used this password";
 
 ?>

--- a/lang/sk.inc.php
+++ b/lang/sk.inc.php
@@ -127,5 +127,6 @@ $messages['sshkey'] = "SSH kľúč";
 $messages['emptysshkeychangeform'] = "Zmeňte svoj SSH kľúč";
 $messages['changesshkeyhelp'] = "Zadajte heslo a nové SSH kľúč.";
 $messages['sshkeyerror'] = "SSH kľúč bol odmietnutý v adresári LDAP";
+$messages['passwordused'] = "You already used this password";
 
 ?>

--- a/lang/sl.inc.php
+++ b/lang/sl.inc.php
@@ -127,5 +127,6 @@ $messages['sshkey'] = "SSH Key";
 $messages['emptysshkeychangeform'] = "Spreminjanje SSH ključ";
 $messages['changesshkeyhelp'] = "Vnesite geslo in nov ključ SSH.";
 $messages['sshkeyerror'] = "SSH Ključna je bila zavrnjena z imeniku LDAP";
+$messages['passwordused'] = "You already used this password";
 
 ?>

--- a/lang/sv.inc.php
+++ b/lang/sv.inc.php
@@ -127,5 +127,6 @@ $messages['sshkey'] = "SSH Key";
 $messages['emptysshkeychangeform'] = "Ändra din SSH Key";
 $messages['changesshkeyhelp'] = "Ange ditt lösenord och ny SSH-nyckel.";
 $messages['sshkeyerror'] = "SSH Key avslogs av LDAP-katalogen";
+$messages['passwordused'] = "You already used this password";
 
 ?>

--- a/lang/tr.inc.php
+++ b/lang/tr.inc.php
@@ -127,5 +127,6 @@ $messages['sshkey'] = "SSH Anahtarı";
 $messages['emptysshkeychangeform'] = "SSH Anahtarınızı Değiştirin";
 $messages['changesshkeyhelp'] = "Parolanızı ve yeni SSH anahtarınızı girin.";
 $messages['sshkeyerror'] = "SSH Anahtarı LDAP dizini tarafından reddedildi";
+$messages['passwordused'] = "You already used this password";
 
 ?>

--- a/lang/uk.inc.php
+++ b/lang/uk.inc.php
@@ -128,5 +128,6 @@ $messages['sshkey'] = "SSH ключ";
 $messages['emptysshkeychangeform'] = "Змінити ключ SSH";
 $messages['changesshkeyhelp'] = "Введіть свій пароль і новий ключ SSH.";
 $messages['sshkeyerror'] = "SSH Key була відхилена каталогом LDAP";
+$messages['passwordused'] = "You already used this password";
 
 ?>

--- a/lang/zh-CN.inc.php
+++ b/lang/zh-CN.inc.php
@@ -127,5 +127,6 @@ $messages['sshkey'] = "SSH密钥";
 $messages['emptysshkeychangeform'] = "更改SSH密钥";
 $messages['changesshkeyhelp'] = "输入您的密码和新的SSH密钥。";
 $messages['sshkeyerror'] = "LDAP目录拒绝了SSH密钥";
+$messages['passwordused'] = "You already used this password";
 
 ?>

--- a/lib/functions.inc.php
+++ b/lib/functions.inc.php
@@ -127,7 +127,8 @@ function user_password_analyzer( $user_password_value ) {
     );
 
     if(!array_key_exists($scheme, $schemes)) {
-        throw new InvalidArgumentException("Password hashing scheme '$scheme' is not supported");
+        error_log("user_password_analyzer: password hashing scheme '$scheme' is not supported");
+        return false;
     }
 
     $hash_and_salt = base64_decode($base64_hash_and_salt);
@@ -168,6 +169,9 @@ function make_generic_password( $password, $scheme, $salt ) {
 # Returns true if $cleartext verifies $user_password_value
 function ldap_password_verify( $cleartext, $user_password_value ) {
     $hash_details = user_password_analyzer($user_password_value);
+
+    # return false if the ldap password could not be analyzed (unknown scheme)
+    if ( false === $hash_details ) return false;
 
     $password = make_generic_password($cleartext, $hash_details['scheme'], $hash_details['salt']);
 

--- a/lib/functions.inc.php
+++ b/lib/functions.inc.php
@@ -178,10 +178,13 @@ function ldap_password_verify( $cleartext, $user_password_value ) {
     return $user_password_value == $password;
 }
 
-# Returns 'passwordused' if a hash for the $cleartext is present in $pwdHistory
-function check_password_history( $cleartext, $pwdHistory ) {
-    foreach ($pwdHistory as $oldPassword) {
-        if(ldap_password_verify($cleartext, $oldPassword)) {
+# Returns 'passwordused' if a hash for the $cleartext is present in $pwdHistoryList
+function check_password_history( $cleartext, $pwdHistoryList ) {
+    foreach ($pwdHistoryList as $value) {
+        # example value 20170213101453Z#1.3.6.1.4.1.1466.115.121.1.40#4#test
+        $pwdHistory = explode('#', $value, 4);
+
+        if(ldap_password_verify($cleartext, $pwdHistory[3])) {
             return 'passwordused';
         }
     }

--- a/lib/functions.inc.php
+++ b/lib/functions.inc.php
@@ -133,10 +133,15 @@ function user_password_analyzer( $user_password_value ) {
 
     $hash_and_salt = base64_decode($base64_hash_and_salt);
 
-    $unpacked = unpack("H{$schemes[$scheme]['size']}hash/a*salt", $hash_and_salt);
+    # salt may contain null bytes
+    $unpacked = unpack("H{$schemes[$scheme]['size']}hash/C*salt", $hash_and_salt);
 
     $password_hash = $unpacked['hash'];
-    $salt          = $schemes[$scheme]['salted'] ? $unpacked['salt'] : false;
+
+    # remove hash to keep only the salt bytes
+    unset($unpacked['hash']);
+    $salt = join('', array_map('chr', $unpacked));
+    $salt = $schemes[$scheme]['salted'] ? $salt : false;
 
     return array (
         'user_password_value' => $user_password_value,

--- a/lib/functions.inc.php
+++ b/lib/functions.inc.php
@@ -211,7 +211,7 @@ function stripslashes_if_gpc_magic_quotes( $string ) {
 # Get message criticity
 function get_criticity( $msg ) {
 
-    if ( preg_match( "/nophpldap|phpupgraderequired|nophpmhash|ldaperror|nomatch|badcredentials|passworderror|tooshort|toobig|minlower|minupper|mindigit|minspecial|forbiddenchars|sameasold|answermoderror|answernomatch|mailnomatch|tokennotsent|tokennotvalid|notcomplex|smsnonumber|smscrypttokensrequired|nophpmbstring|nophpxml|smsnotsent|sameaslogin/" , $msg ) ) {
+    if ( preg_match( "/nophpldap|phpupgraderequired|nophpmhash|ldaperror|nomatch|badcredentials|passworderror|passwordused|tooshort|toobig|minlower|minupper|mindigit|minspecial|forbiddenchars|sameasold|answermoderror|answernomatch|mailnomatch|tokennotsent|tokennotvalid|notcomplex|smsnonumber|smscrypttokensrequired|nophpmbstring|nophpxml|smsnotsent|sameaslogin/" , $msg ) ) {
     return "danger";
     }
 

--- a/pages/change.php
+++ b/pages/change.php
@@ -34,6 +34,7 @@ $ldap = "";
 $userdn = "";
 if (!isset($pwd_forbidden_chars)) { $pwd_forbidden_chars=""; }
 $mail = "";
+$pwdHistory = array ();
 
 if (isset($_POST["confirmpassword"]) and $_POST["confirmpassword"]) { $confirmpassword = $_POST["confirmpassword"]; }
  else { $result = "confirmpasswordrequired"; }
@@ -131,6 +132,14 @@ if ( $result === "" ) {
         }
     }
 
+    if ( $check_password_history ) {
+        $values = ldap_get_values($ldap, $entry, $password_history_attribute);
+        if(isset($values[0])) {
+            unset($values['count']);
+            $pwdHistory = $values;
+        }
+    }
+
     # Check objectClass to allow samba and shadow updates
     $ocValues = ldap_get_values($ldap, $entry, 'objectClass');
     if ( !in_array( 'sambaSamAccount', $ocValues ) and !in_array( 'sambaSAMAccount', $ocValues ) ) {
@@ -180,6 +189,12 @@ if ( $result === "" ) {
     $result = check_password_strength( $newpassword, $oldpassword, $pwd_policy_config, $login );
 }
 
+#==============================================================================
+# Check password history
+#==============================================================================
+if ( $check_password_history && $result === "" ) {
+    $result = check_password_history( $newpassword, $pwdHistory );
+}
 
 #==============================================================================
 # Change password

--- a/pages/change.php
+++ b/pages/change.php
@@ -132,8 +132,8 @@ if ( $result === "" ) {
         }
     }
 
-    if ( $check_password_history ) {
-        $values = ldap_get_values($ldap, $entry, $password_history_attribute);
+    if ( $ppolicy_options['check_password_history'] ) {
+        $values = ldap_get_values($ldap, $entry, 'pwdHistory');
         if(isset($values[0])) {
             unset($values['count']);
             $pwdHistory = $values;
@@ -192,7 +192,7 @@ if ( $result === "" ) {
 #==============================================================================
 # Check password history
 #==============================================================================
-if ( $check_password_history && $result === "" ) {
+if ( $ppolicy_options['check_password_history'] && $result === "" ) {
     $result = check_password_history( $newpassword, $pwdHistory );
 }
 

--- a/pages/resetbyquestions.php
+++ b/pages/resetbyquestions.php
@@ -35,6 +35,7 @@ $ldap = "";
 $userdn = "";
 if (!isset($pwd_forbidden_chars)) { $pwd_forbidden_chars=""; }
 $mail = "";
+$pwdHistory = array ();
 
 if (isset($_POST["confirmpassword"]) and $_POST["confirmpassword"]) { $confirmpassword = $_POST["confirmpassword"]; }
  else { $result = "confirmpasswordrequired"; }
@@ -140,7 +141,15 @@ if ( $result === "" ) {
         if ( $mailValues["count"] > 0 ) {
             $mail = $mailValues[0];
         }
-    } 
+    }
+
+    if ( $check_password_history ) {
+        $values = ldap_get_values($ldap, $entry, $password_history_attribute);
+        if(isset($values[0])) {
+            unset($values['count']);
+            $pwdHistory = $values;
+        }
+    }
 
     # Get question/answer values
     $questionValues = ldap_get_values($ldap, $entry, $answer_attribute);
@@ -173,6 +182,11 @@ if ( $result === "" ) {
 # Check password strength
 if ( $result === "" ) {
     $result = check_password_strength( $newpassword, "", $pwd_policy_config, $login );
+}
+
+# Check password history
+if ( $check_password_history && $result === "" ) {
+    $result = check_password_history( $newpassword, $pwdHistory );
 }
 
 # Change password

--- a/pages/resetbyquestions.php
+++ b/pages/resetbyquestions.php
@@ -143,8 +143,8 @@ if ( $result === "" ) {
         }
     }
 
-    if ( $check_password_history ) {
-        $values = ldap_get_values($ldap, $entry, $password_history_attribute);
+    if ( $ppolicy_options['check_password_history'] ) {
+        $values = ldap_get_values($ldap, $entry, 'pwdHistory');
         if(isset($values[0])) {
             unset($values['count']);
             $pwdHistory = $values;
@@ -185,7 +185,7 @@ if ( $result === "" ) {
 }
 
 # Check password history
-if ( $check_password_history && $result === "" ) {
+if ( $ppolicy_options['check_password_history'] && $result === "" ) {
     $result = check_password_history( $newpassword, $pwdHistory );
 }
 

--- a/pages/resetbytoken.php
+++ b/pages/resetbytoken.php
@@ -35,6 +35,7 @@ $ldap = "";
 $userdn = "";
 if (!isset($pwd_forbidden_chars)) { $pwd_forbidden_chars=""; }
 $mail = "";
+$pwdHistory = array ();
 
 if (isset($_REQUEST["token"]) and $_REQUEST["token"]) { $token = $_REQUEST["token"]; }
  else { $result = "tokenrequired"; }
@@ -178,6 +179,14 @@ if ( $result === "" ) {
         }
     }
 
+    if ( $check_password_history ) {
+        $values = ldap_get_values($ldap, $entry, $password_history_attribute);
+        if(isset($values[0])) {
+            unset($values['count']);
+            $pwdHistory = $values;
+        }
+    }
+
 }}}}
 
 #==============================================================================
@@ -191,6 +200,11 @@ if ( $result === "" ) {
 # Check password strength
 if ( $result === "" ) {
     $result = check_password_strength( $newpassword, "", $pwd_policy_config, $login );
+}
+
+# Check password history
+if ( $check_password_history && $result === "" ) {
+    $result = check_password_history($newpassword, $pwdHistory);
 }
 
 # Change password

--- a/pages/resetbytoken.php
+++ b/pages/resetbytoken.php
@@ -179,8 +179,8 @@ if ( $result === "" ) {
         }
     }
 
-    if ( $check_password_history ) {
-        $values = ldap_get_values($ldap, $entry, $password_history_attribute);
+    if ( $ppolicy_options['check_password_history'] ) {
+        $values = ldap_get_values($ldap, $entry, 'pwdHistory');
         if(isset($values[0])) {
             unset($values['count']);
             $pwdHistory = $values;
@@ -203,7 +203,7 @@ if ( $result === "" ) {
 }
 
 # Check password history
-if ( $check_password_history && $result === "" ) {
+if ( $ppolicy_options['check_password_history'] && $result === "" ) {
     $result = check_password_history($newpassword, $pwdHistory);
 }
 

--- a/tests/HashingTest.php
+++ b/tests/HashingTest.php
@@ -87,5 +87,20 @@ class HashingTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue(ldap_password_verify($password, $hash));
         $this->assertFalse(ldap_password_verify($wrongpassword, $hash));
     }
+
+    /**
+     * Test check password history function
+     */
+    public function testCheckPasswordHistory() {
+        $pwdHistory = array (
+            '20170217112113Z#1.3.6.1.4.1.1466.115.121.1.40#38#{SSHA}m7Be77fKQfm32blISCpzEMFNkRxUKW8A',
+            '20170127181243Z#1.3.6.1.4.1.1466.115.121.1.40#38#{SSHA}+H+T7c7YN2MiGaczxjVjODnOKmNzUGx7',
+            '20170113144233Z#1.3.6.1.4.1.1466.115.121.1.40#24#{SMD5}BTKHjNdmNzmouyA7+8Pwl7rjyqY=',
+        );
+
+        $this->assertSame('', check_password_history('A new password', $pwdHistory));
+        $this->assertSame('passwordused', check_password_history('luna', $pwdHistory));
+        $this->assertSame('passwordused', check_password_history('p4ssw0rd', $pwdHistory));
+    }
 }
 

--- a/tests/HashingTest.php
+++ b/tests/HashingTest.php
@@ -1,0 +1,91 @@
+<?php
+
+require_once __DIR__ . '/../lib/vendor/defuse-crypto.phar';
+require_once __DIR__ . '/../lib/functions.inc.php';
+
+class HashingTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Test hashing functions
+     */
+    public function testHashingFunctions()
+    {
+        $password = "p4ssw0rd";
+        $wrongpassword = "badpass";
+
+        // MD5
+        $hash = make_md5_password($password);
+        $hash_details = user_password_analyzer($hash);
+
+        $this->assertSame("MD5", $hash_details['scheme']);
+        $this->assertFalse($hash_details['salt']);
+
+        $this->assertSame($hash, make_md5_password($password));
+
+        $this->assertTrue(ldap_password_verify($password, $hash));
+        $this->assertFalse(ldap_password_verify($wrongpassword, $hash));
+
+        // SMD5
+        $hash = make_smd5_password($password);
+        $hash_details = user_password_analyzer($hash);
+
+        $this->assertSame("SMD5", $hash_details['scheme']);
+        $this->assertNotFalse($hash_details['salt']);
+
+        $this->assertSame($hash, make_smd5_password($password, $hash_details['salt']));
+        $this->assertNotSame($hash, make_smd5_password($password, "wrongsalt"));
+
+        $this->assertTrue(ldap_password_verify($password, $hash));
+        $this->assertFalse(ldap_password_verify($wrongpassword, $hash));
+
+        // SHA
+        $hash = make_sha_password($password);
+        $hash_details = user_password_analyzer($hash);
+
+        $this->assertSame("SHA", $hash_details['scheme']);
+        $this->assertFalse($hash_details['salt']);
+
+        $this->assertSame($hash, make_sha_password($password));
+
+        $this->assertTrue(ldap_password_verify($password, $hash));
+        $this->assertFalse(ldap_password_verify($wrongpassword, $hash));
+
+        // SSHA
+        $hash = make_ssha_password($password);
+        $hash_details = user_password_analyzer($hash);
+
+        $this->assertSame("SSHA", $hash_details['scheme']);
+        $this->assertNotFalse($hash_details['salt']);
+
+        $this->assertSame($hash, make_ssha_password($password, $hash_details['salt']));
+        $this->assertNotSame($hash, make_ssha_password($password, "wrongsalt"));
+
+        $this->assertTrue(ldap_password_verify($password, $hash));
+        $this->assertFalse(ldap_password_verify($wrongpassword, $hash));
+
+        // SHA512
+        $hash = make_sha512_password($password);
+        $hash_details = user_password_analyzer($hash);
+
+        $this->assertSame("SHA512", $hash_details['scheme']);
+        $this->assertFalse($hash_details['salt']);
+
+        $this->assertSame($hash, make_sha512_password($password));
+
+        $this->assertTrue(ldap_password_verify($password, $hash));
+        $this->assertFalse(ldap_password_verify($wrongpassword, $hash));
+
+        // crypt
+        $hash_options = array('crypt_salt_prefix' => '$6$32');
+        $hash = make_crypt_password($password, $hash_options);
+        $hash_details = user_password_analyzer($hash);
+
+        $this->assertSame("CRYPT", $hash_details['scheme']);
+        $this->assertNotSame($hash, make_crypt_password("bad password", $hash_options, $hash_details['salt']));
+        $this->assertSame($hash, make_crypt_password($password, $hash_options, $hash_details['salt']));
+
+        $this->assertTrue(ldap_password_verify($password, $hash));
+        $this->assertFalse(ldap_password_verify($wrongpassword, $hash));
+    }
+}
+


### PR DESCRIPTION
PR for discussion. Not ready for merge.

Solves https://github.com/ltb-project/self-service-password/issues/57

What to do if there is a hash in password history uses a not supported scheme ? Ignore + log ?

Is the message "You already used this password"; sufficient ?

Is this implementation correct ? I tried to find inspiration in fusion directory but I fail to understand how  [they handle this](https://github.com/fusiondirectory/fusiondirectory/blob/df4f925d1c014d451844c646e70cdd7aa971f4e1/plugins/personal/generic/class_user.inc#L633). 

@cybert0x would you agree to test this branch ?