### PR TITLE
Fix invalid html in sendsms.php

### DIFF
--- a/pages/sendsms.php
+++ b/pages/sendsms.php
@@ -351,7 +351,7 @@ if ( $result == "smscrypttokensrequired" ) {
             </div>
         </div>
     </div>
-    <input type="hidden" name="token" value=<?php echo htmlentities($token) ?> />
+    <input type="hidden" name="token" value="<?php echo htmlentities($token) ?>" />
     <div class="form-group">
         <div class="col-sm-offset-4 col-sm-8">
             <button type="submit" class="btn btn-success">


### PR DESCRIPTION
Related to https://github.com/ltb-project/self-service-password/pull/102

I am not sure if there is a bug, the html could be misinterpreted if the base64 contains "/"