### PR TITLE
Sanitize Mobile Number retrieved from LDAP

### DIFF
--- a/pages/sendsms.php
+++ b/pages/sendsms.php
@@ -180,6 +180,8 @@ if ( $result === "" ) {
     # Check sms number
     if ( $smsValues["count"] > 0 ) {
         $sms = $smsValues[0];
+          $sms = preg_replace('/[^0-9]/','',$sms);
+          $sms = substr($sms, -10);
     }
 
     if ( !$sms ) {


### PR DESCRIPTION
I have the issue that mobile numbers stored in LDAP are variable format as hard as I have tried to get people. The format is always different.
1(NNN) NNN-NNNN
+1 NNN.NNN.NNNN
NNN-NNN-NNNN

etc.

This simple patch sanitize the number format so email to sms will work no matter how it's stored. 
It can then be converted to 1NNNNNNNNN@smsemaildomain.foo without needing constantly 'fix' the mobile attribute in LDAP.

Cheers