### PR TITLE
Allow user to change expired password

### DIFF
--- a/conf/config.inc.php
+++ b/conf/config.inc.php
@@ -40,8 +40,6 @@ $ad_mode = false;
 $ad_options['force_unlock'] = false;
 # Force user change password at next login
 $ad_options['force_pwd_change'] = false;
-# Allow user with expired password to change password
-$ad_options['change_expired_password'] = false;
 
 # Samba mode
 # true: update sambaNTpassword and sambaPwdLastSet attributes too
@@ -145,6 +143,9 @@ $use_questions = true;
 # Answer attribute should be hidden to users!
 $answer_objectClass = "extensibleObject";
 $answer_attribute = "info";
+
+# Allow change of expired password
+$change_expired_password = "false";
 
 # Extra questions (built-in questions are in lang/$lang.inc.php)
 #$messages['questions']['ice'] = "What is your favorite ice cream flavor?";

--- a/pages/change.php
+++ b/pages/change.php
@@ -152,13 +152,49 @@ if ( $result === "" ) {
                 error_log("LDAP - Bind user password needs to be changed");
                 $errno = 0;
             }
-            if ( ( strpos($extended_error[2], '532') or strpos($extended_error[0], 'NT_STATUS_ACCOUNT_EXPIRED') ) and $ad_options['change_expired_password'] ) {
+            if ( ( strpos($extended_error[2], '532') or strpos($extended_error[0], 'NT_STATUS_ACCOUNT_EXPIRED') ) and $change_expired_password ) {
                 error_log("LDAP - Bind user password is expired");
                 $errno = 0;
             }
             unset($extended_error);
         }
+    } elseif ( ! $ad_mode && ($errno == 49) && $change_expired_password && ( $who_change_password == "manager" ) ) {
+        # Try to check password value without binding
+        # First rebind as Manager, it will be needed (since our user can't log in)
+        $bind = ldap_bind($ldap, $ldap_binddn, $ldap_bindpw);
+
+        # Check that the password is not locked (due to several attempts for example)
+        $search_password_info = ldap_read( $ldap, $userdn, "(objectClass=*)", array("pwdAccountLockedTime", "userPassword") );
+
+        # Read LDAP password value
+        #$search_password_info = ldap_read( $ldap, $userdn, "(objectClass=*)", array("userPassword") );
+        if ( $search_password_info ) {
+            $first_entry = ldap_first_entry($ldap, $search_password_info);
+            $pwd_locked = ldap_get_values($ldap, $first_entry, "pwdAccountLockedTime");
+            if ( isset($pwd_locked) ) {
+                #LDAP attribute pwdAccountLockedTime is still set after our earlier ldap_bind attempt: user is locked out
+                error_log("LDAP - denying password change - user ". $login ." is locked out");
+            }
+            else {
+                $password_val = ldap_get_values($ldap, $first_entry, "userPassword");
+                if ( isset($password_val) ) {
+                    $old_pwd_hashed = hash_old_password($password_val[0], $oldpassword);
+
+                    if ( hash_equals($password_val[0], $old_pwd_hashed)) {
+                        # Hashes match: user can't log in for some reason (expired, most likely) but we should allow a password change
+                        error_log("LDAP - Allowing password change for user " . $login . "despite bind unsuccessful");
+                        $errno = 0;
+                    }
+                    else {
+                        error_log("LDAP - denying password change - passwords don't match");
+                    }
+                }
+            }
+        } else {
+            error_log("Denying password change - user does not exist");
+        }
     }
+
     if ( $errno ) {
         $result = "badcredentials";
         error_log("LDAP - Bind user error $errno  (".ldap_error($ldap).")");

--- a/tests/HashOldPasswordTest.php
+++ b/tests/HashOldPasswordTest.php
@@ -1,0 +1,95 @@
+<?php
+
+require_once __DIR__ . '/../lib/vendor/defuse-crypto.phar';
+
+class HashOldPasswordTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Test hash_old_password function
+     */
+    public function testHashOldPassword()
+    {
+
+        # Load functions
+        require_once("lib/functions.inc.php");
+
+		$candidate_password = "hello_S3lfServ1ce";
+		
+		# Test SSHA hashed password
+		$ldap_password = '{SSHA}/oFcrDRwH5K6Gv3ng1D9I+m32ftIpGivlUB6jw=='; # Obtained via Apache Directory Studio
+		$candidate_hashed = hash_old_password($ldap_password, $candidate_password);
+		$this->assertEquals($ldap_password, $candidate_hashed);
+		
+		# Test SHA1 hashed password
+		$ldap_password = '{SHA}cxMgpYJFOW1BPAkO4tbAHXwz9Z0='; # Obtained via Apache Directory Studio
+		$candidate_hashed = hash_old_password($ldap_password, $candidate_password);
+		$this->assertEquals($ldap_password, $candidate_hashed);
+		
+		# Test SHA512 hashed password
+		$ldap_password = '{SHA512}Eg8xKRGYinaxsrM4edoROEUcQoqFRDI3Slcg5wWig80g1VpYFx+DQVqA++TN2B44XDoSMjRkwCOcgrRS+wsS1g=='; # Obtained via Apache Directory Studio
+		$candidate_hashed = hash_old_password($ldap_password, $candidate_password);
+		$this->assertEquals($ldap_password, $candidate_hashed);
+		
+		# Test SMD5 hashed password
+		$ldap_password = '{SMD5}xT4bI4kPLtAmUYjmRqT2t0H+PTHjFY4C'; # Obtained via Apache Directory Studio
+		$candidate_hashed = hash_old_password($ldap_password, $candidate_password);
+		$this->assertEquals($ldap_password, $candidate_hashed);
+		
+		# Test MD5 hashed password
+		$ldap_password = '{MD5}iNCvX+AiYnAeZoORPjwOuw=='; # Obtained via Apache Directory Studio
+		$candidate_hashed = hash_old_password($ldap_password, $candidate_password);
+		$this->assertEquals($ldap_password, $candidate_hashed);
+		
+		
+		# Test CRYPT hashed password - standard DES
+		$ldap_password = '{CRYPT}WCFar/a24WRlk'; # Obtained via Apache Directory Studio
+		$candidate_hashed = hash_old_password($ldap_password, $candidate_password);
+		$this->assertEquals($ldap_password, $candidate_hashed);
+		
+		# Test CRYPT hashed password - extended DES
+		$ldap_password = '{CRYPT}_6uVCtbvym/90wKTIrKY'; 
+		# Generated using random 8-chars string from https://www.random.org/strings/ and https://quickhash.com/ Extended DES algorithm
+		$candidate_hashed = hash_old_password($ldap_password, $candidate_password);
+		$this->assertEquals($ldap_password, $candidate_hashed);
+		
+		# Test CRYPT hashed password - md5 hash
+		$ldap_password = '{CRYPT}$1$akUYgSg4$WQceCqgPDPgefRr/Zutj70'; # Obtained via Apache Directory Studio
+		$candidate_hashed = hash_old_password($ldap_password, $candidate_password);
+		$this->assertEquals($ldap_password, $candidate_hashed);
+		
+		# Test CRYPT hashed password - Blowfish hash with 2a
+		$ldap_password = '{CRYPT}$2a$06$1ZJSTvTH9xju5zGUoXuMIuDSFw57SLYopcqamCKQYeUgfeUbndMNW'; 
+		# Above password generated using random string from https://www.random.org/strings/ and http://php.fnlist.com/crypt_hash/crypt online calculation
+		$candidate_hashed = hash_old_password($ldap_password, $candidate_password);
+		$this->assertEquals($ldap_password, $candidate_hashed);
+		
+		# Test CRYPT hashed password - Blowfish hash with 2y
+		$ldap_password = '{CRYPT}$2y$06$1ZJSTvTH9xju5zGUoXuMIuDSFw57SLYopcqamCKQYeUgfeUbndMNW';
+		# Above password generated using random string from https://www.random.org/strings/ and http://php.fnlist.com/crypt_hash/crypt online calculation
+		$candidate_hashed = hash_old_password($ldap_password, $candidate_password);
+		$this->assertEquals($ldap_password, $candidate_hashed);
+		
+		# Test CRYPT hashed password - sha256 sum
+		$ldap_password = '{CRYPT}$5$4mxifKQN$PRzssKp/vzWdcN3QNXSOuutw7vbS6pR4hgtp9AboH83'; # Obtained via Apache Directory Studio
+		$candidate_hashed = hash_old_password($ldap_password, $candidate_password);
+		$this->assertEquals($ldap_password, $candidate_hashed);
+		
+		# Test CRYPT hashed password - sha256 sum with custom rounds value
+		$ldap_password = '{CRYPT}$5$rounds=12345$eKNy1/RDIlJ$gehYUSLkKuhof/Sbp.N7XHdAe/U6hi1G9ZrdEgDbPx8'; 
+		#Above pass obtained via linux command :  echo "username:hello_S3lfServ1ce" | chpasswd -c SHA256 -s 12345 and copying /etc/shadow value
+		$candidate_hashed = hash_old_password($ldap_password, $candidate_password);
+		$this->assertEquals($ldap_password, $candidate_hashed);
+		
+		# Test CRYPT hashed password - sha512 sum
+		$ldap_password = '{CRYPT}$6$T87Jnfqj$6gdQfurLrxU0E6TxzdiklrT1QTDPFTO06vIkDBN2Frx4WMJNr.uMWUm4basMbu8D7mEFVFxXkEED72DNPzoYH.'; # Obtained via Apache Directory Studio
+		$candidate_hashed = hash_old_password($ldap_password, $candidate_password);
+		$this->assertEquals($ldap_password, $candidate_hashed);
+		
+		# Test CRYPT hashed password - sha512 sum with custom rounds value
+		$ldap_password = '{CRYPT}$6$rounds=12345$mgoMm/FzDwtJjkr$j0zvqlK9Tn/iTpEgnKFMCW8us1x.ex54qpzljcCXZfVJL2FHvNg7t2fjdCfqKb7HNMvRC838XdJdiyUmaIkzs/'; 
+		#Above pass obtained via linux command :  echo "username:hello_S3lfServ1ce" | chpasswd -c SHA512 -s 12345 and copying /etc/shadow value
+		$candidate_hashed = hash_old_password($ldap_password, $candidate_password);
+		$this->assertEquals($ldap_password, $candidate_hashed);
+    }
+}
+


### PR DESCRIPTION
Hi,

I really needed to solve the issue #96 so I did it myself. Here is the pull request, feel free to add it to master if you feel like it's a good idea. 

I tested the following cases with OpenLDAP:
* it allows users with an expired password to change their password anyway
* it remembers a wrong password when the old one is incorrect, adding a "pwdFailureTime" attribute
* it won't change a password if the user is locked out

It might require additional testing with Active Directory for regression testing, and maybe with several other LDAP providers. Also, I did the realtime testing with SSHA-hashed passwords, only the unit test hashes the password with all other possible encryptions.

Thanks @coudot for your help on this one
