### PR TITLE
Add possibility to force use of a specific set of languages

### DIFF
--- a/conf/config.inc.php
+++ b/conf/config.inc.php
@@ -222,7 +222,7 @@ $show_help = true;
 # Default language
 $lang = "en";
 
-# List of authorized languages. If empty, all language are allowed. 
+# List of authorized languages. If empty, all language are allowed.
 # If not empty and the user's browser language setting is not in that list, language from $lang will be used.
 $allowed_lang = array();
 

--- a/conf/config.inc.php
+++ b/conf/config.inc.php
@@ -219,8 +219,12 @@ $max_attempts = 3;
 # Display help messages
 $show_help = true;
 
-# Language
-$lang ="auto";
+# Default language
+$lang = "en";
+
+# List of authorized languages. If empty, all language are allowed. 
+# If not empty and the user's browser language setting is not in that list, language from $lang will be used.
+$allowed_lang = array();
 
 # Display menu on top
 $show_menu = true;

--- a/conf/config.inc.php
+++ b/conf/config.inc.php
@@ -220,7 +220,7 @@ $max_attempts = 3;
 $show_help = true;
 
 # Language
-$lang ="en";
+$lang ="auto";
 
 # Display menu on top
 $show_menu = true;

--- a/index.php
+++ b/index.php
@@ -38,16 +38,24 @@ require_once("lib/vendor/PHPMailer/PHPMailerAutoload.php");
 $languages = array();
 if ($handle = opendir('lang')) {
     while (false !== ($entry = readdir($handle))) {
-        if ($entry != "." && $entry != "..") {
-             array_push($languages, str_replace(".inc.php", "", $entry));
+        if ($entry != "." && $entry != ".." ) {
+            $entry_lang = str_replace(".inc.php", "", $entry);
+            # Only add language to possibilities if it is the default language or part of the allowed languages 
+            # empty $allowed_lang <=> all languages are allowed
+            if ($entry_lang == $lang || empty($allowed_lang) || in_array($entry_lang, $allowed_lang) ) {
+                array_push($languages, $entry_lang);
+            }
         }
     }
     closedir($handle);
 }
-if(!isset($lang) or $lang == "auto") {
-    $lang = detectLanguage($lang, $languages);
+$lang = detectLanguage($lang, $languages);
+if (file_exists("lang/$lang.inc.php")) {
+    require_once("lang/$lang.inc.php");
+} else {
+    # Fall back to english if default $lang does not actually exist
+    require_once("lang/en.inc.php");
 }
-require_once("lang/$lang.inc.php");
 if (file_exists("conf/$lang.inc.php")) {
     require_once("conf/$lang.inc.php");
 }

--- a/index.php
+++ b/index.php
@@ -55,6 +55,7 @@ if (file_exists("lang/$lang.inc.php")) {
 } else {
     # Fall back to english if default $lang does not actually exist
     require_once("lang/en.inc.php");
+    error_log('Invalid configuration file, no language file associated with $lang value ' . $lang . '. Switching to english.');
 }
 if (file_exists("conf/$lang.inc.php")) {
     require_once("conf/$lang.inc.php");

--- a/index.php
+++ b/index.php
@@ -44,7 +44,9 @@ if ($handle = opendir('lang')) {
     }
     closedir($handle);
 }
-$lang = detectLanguage($lang, $languages);
+if(!isset($lang) or $lang == "auto") {
+    $lang = detectLanguage($lang, $languages);
+}
 require_once("lang/$lang.inc.php");
 if (file_exists("conf/$lang.inc.php")) {
     require_once("conf/$lang.inc.php");

--- a/index.php
+++ b/index.php
@@ -32,6 +32,12 @@ require_once("lib/detectbrowserlanguage.php");
 require_once("lib/vendor/PHPMailer/PHPMailerAutoload.php");
 
 #==============================================================================
+# Error reporting
+#==============================================================================
+error_reporting(0);
+if($debug) error_reporting(E_ALL);
+
+#==============================================================================
 # Language
 #==============================================================================
 # Available languages
@@ -40,7 +46,7 @@ if ($handle = opendir('lang')) {
     while (false !== ($entry = readdir($handle))) {
         if ($entry != "." && $entry != ".." ) {
             $entry_lang = str_replace(".inc.php", "", $entry);
-            # Only add language to possibilities if it is the default language or part of the allowed languages 
+            # Only add language to possibilities if it is the default language or part of the allowed languages
             # empty $allowed_lang <=> all languages are allowed
             if ($entry_lang == $lang || empty($allowed_lang) || in_array($entry_lang, $allowed_lang) ) {
                 array_push($languages, $entry_lang);
@@ -50,22 +56,10 @@ if ($handle = opendir('lang')) {
     closedir($handle);
 }
 $lang = detectLanguage($lang, $languages);
-if (file_exists("lang/$lang.inc.php")) {
-    require_once("lang/$lang.inc.php");
-} else {
-    # Fall back to english if default $lang does not actually exist
-    require_once("lang/en.inc.php");
-    error_log('Invalid configuration file, no language file associated with $lang value ' . $lang . '. Switching to english.');
-}
+require_once("lang/$lang.inc.php");
 if (file_exists("conf/$lang.inc.php")) {
     require_once("conf/$lang.inc.php");
 }
-
-#==============================================================================
-# Error reporting
-#==============================================================================
-error_reporting(0);
-if($debug) error_reporting(E_ALL);
 
 #==============================================================================
 # PHP configuration tuning


### PR DESCRIPTION
As disscussed in issue #115.

Tested following cases:
* One of the browser languages is in the allowed languages => browser language selected;
* None is => default language is used;
* Default language is/is not included in the allowed languages => in both cases, browser or default language is selected, depending if browser language is in allowed languages list ;
* Default language matches / does not match an existing lang file => in the unlikely case where the browser language doesn't match any allowed languages, and the default languages does not have any `$lang.inc.php` file, fall back to english

Any comments are welcome