### PR TITLE
Fix hhvm on travis, update travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: php
 
+dist: trusty
+
 php:
   - '5.4'
   - '5.5'

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ php:
   - '5.6'
   - '7.0'
   - '7.1'
-  - hhvm
 
 before_install:
   # If PHP >= 7.0, force use of PHPUnit 5.7


### PR DESCRIPTION
HHVM dropped support of ubuntu precise.
Travis use ubuntu precise containers by default.

There is basically two options :
1. Drop tests on hhvm
2. Configure travis to use ubuntu trusty, still in beta 

The other travis users having the same issue seem to all move to ubuntu trusty. ~~I suggest the same.~~
https://github.com/travis-ci/travis-ci/issues/7712

EDIT: HHVM with our old version of phpunit seems unreliable, this PR now proposes its removal