### PR TITLE
Add popovers to explain menu links (cf. issue #111)

### DIFF
--- a/index.php
+++ b/index.php
@@ -225,6 +225,15 @@ $mailer->LE            = $mail_newline;
 
 <script src="js/jquery-1.10.2.min.js"></script>
 <script src="js/bootstrap.min.js"></script>
-
+<script>
+    $(document).ready(function(){
+        // Menu links popovers
+        $('[data-toggle="menu-popover"]').popover({
+            trigger: 'hover',
+            placement: 'bottom',
+            container: 'body' // Allows the popover to be larger than the menu button
+        });
+    });
+</script>
 </body>
 </html>

--- a/menu.php
+++ b/menu.php
@@ -15,22 +15,34 @@
               <ul class="nav navbar-nav">
                 <?php if ( $use_questions ) { ?>
                 <li class="<?php if ( $action === "resetbyquestions" or $action === "setquestions" ) { echo "active"; } ?>">
-                  <a href="?action=resetbyquestions"><i class="fa fa-fw fa-question-circle"></i> <?php echo $messages["menuquestions"]; ?></a>
+                  <a href="?action=resetbyquestions"
+                     data-toggle="menu-popover"
+                     data-content="<?php echo htmlentities(strip_tags($messages["changehelpquestions"])); ?>"
+                  ><i class="fa fa-fw fa-question-circle"></i> <?php echo $messages["menuquestions"]; ?></a>
                 </li>
                 <?php } ?>
                 <?php if ( $use_tokens ) { ?>
                 <li class="<?php if ( ( $action === "resetbytoken" and $source !== "sms" ) or $action === "sendtoken" ) { echo "active"; } ?>">
-                  <a href="?action=sendtoken"><i class="fa fa-fw fa-envelope"></i> <?php echo $messages["menutoken"]; ?></a>
+                  <a href="?action=sendtoken"
+                     data-toggle="menu-popover"
+                     data-content="<?php echo htmlentities(strip_tags($messages["changehelptoken"])); ?>"
+                  ><i class="fa fa-fw fa-envelope"></i> <?php echo $messages["menutoken"]; ?></a>
                 </li>
                 <?php } ?>
                 <?php if ( $use_sms ) { ?>
                 <li class="<?php if ( ( $action === "resetbytoken" and $source === "sms" ) or $action === "sendsms" ) { echo "active"; } ?>">
-                  <a href="?action=sendsms"><i class="fa fa-fw fa-mobile"></i> <?php echo $messages["menusms"]; ?></a>
+                  <a href="?action=sendsms"
+                     data-toggle="menu-popover"
+                     data-content="<?php echo htmlentities(strip_tags($messages["changehelpsms"])); ?>"
+                  ><i class="fa fa-fw fa-mobile"></i> <?php echo $messages["menusms"]; ?></a>
                 </li>
                 <?php } ?>
                 <?php if ( $change_sshkey ) { ?>
                 <li class="<?php if ( $action === "changesshkey" ) { echo "active"; } ?>">
-                  <a href="?action=changesshkey"><i class="fa fa-fw fa-terminal"></i> <?php echo $messages["menusshkey"]; ?></a>
+                  <a href="?action=changesshkey"
+                     data-toggle="menu-popover"
+                     data-content="<?php echo htmlentities(strip_tags($messages["changehelpsshkey"])); ?>"
+                  ><i class="fa fa-fw fa-terminal"></i> <?php echo $messages["menusshkey"]; ?></a>
                 </li>
                 <?php } ?>
               </ul>


### PR DESCRIPTION
Fixes  #111,

It reuses help messages `changehelp*` to avoid adding new ones.
Because they potentially have an `<a>` link, messages are stripped with `strip_tags`.

I didn't want to change the menu messages by longer ones, I think popovers to explain the menu links is a better solution.
It uses jquery & bootstrap for the popovers, it can be avoided by using the native "title" but in my opinion it is not as good looking and quite slow to appear. The bootstrap popover looks better and can't be missed when the pointer is hover the links.

![capt-popover](https://user-images.githubusercontent.com/707245/27684073-a2b71cd0-5cc8-11e7-9ac5-e9ba675d9104.jpg)

cc @roumano 