### PR TITLE
Allow override of reCAPTCHA request method (cf. issue #130)

### DIFF
--- a/conf/config.inc.php
+++ b/conf/config.inc.php
@@ -266,7 +266,7 @@ $recaptcha_theme = "light";
 $recaptcha_type = "image";
 $recaptcha_size = "normal";
 # reCAPTCHA request method, null for default, Fully Qualified Class Name to override
-# Useful when allow_url_fopen=0 ex. $recaptcha_request_method = '\ReCaptcha\RequestMethod\Socket';
+# Useful when allow_url_fopen=0 ex. $recaptcha_request_method = '\ReCaptcha\RequestMethod\CurlPost';
 $recaptcha_request_method = null;
 
 ## Default action

--- a/conf/config.inc.php
+++ b/conf/config.inc.php
@@ -265,6 +265,9 @@ $recaptcha_privatekey = "";
 $recaptcha_theme = "light";
 $recaptcha_type = "image";
 $recaptcha_size = "normal";
+# reCAPTCHA request method, null for default, Fully Qualified Class Name to override
+# Useful when allow_url_fopen=0 ex. $recaptcha_request_method = '\ReCaptcha\RequestMethod\Socket';
+$recaptcha_request_method = null;
 
 ## Default action
 # change

--- a/lib/functions.inc.php
+++ b/lib/functions.inc.php
@@ -488,4 +488,27 @@ function check_username_validity($username,$login_forbidden_chars) {
     return $result;
 }
 
+/* @function string check_recaptcha(string $recaptcha_privatekey, null|string $recaptcha_request_method, string $response, string $login)
+ * Check if $response verifies the reCAPTCHA by asking the recaptcha server, logs if errors
+ * @param $recaptcha_privatekey string shared secret with reCAPTCHA server
+ * @param $recaptcha_request_method null|string FQCN of request method, null for default
+ * @param $response string response provided by user
+ * @param $login string for logging purposes only
+ * @return string empty string if the response is verified successfully, else string 'badcaptcha'
+ */
+function check_recaptcha($recaptcha_privatekey, $recaptcha_request_method, $response, $login) {
+    $recaptcha = new \ReCaptcha\ReCaptcha($recaptcha_privatekey, is_null($recaptcha_request_method) ? null : new $recaptcha_request_method());
+    $resp = $recaptcha->verify($response, $_SERVER['REMOTE_ADDR']);
+
+    if (!$resp->isSuccess()) {
+        error_log("Bad reCAPTCHA attempt with user $login");
+        foreach ($resp->getErrorCodes() as $code) {
+            error_log("reCAPTCHA error: $code");
+        }
+        return 'badcaptcha';
+    }
+
+    return '';
+}
+
 ?>

--- a/pages/change.php
+++ b/pages/change.php
@@ -65,7 +65,7 @@ if ( $newpassword != $confirmpassword ) { $result="nomatch"; }
 #==============================================================================
 if ( $result === "" ) {
     if ( $use_recaptcha) {
-        $recaptcha = new \ReCaptcha\ReCaptcha($recaptcha_privatekey);
+        $recaptcha = new \ReCaptcha\ReCaptcha($recaptcha_privatekey, is_null($recaptcha_request_method) ? null : new $recaptcha_request_method());
         $resp = $recaptcha->verify($_POST['g-recaptcha-response'], $_SERVER['REMOTE_ADDR']);
         if (!$resp->isSuccess()) {
             $result = "badcaptcha";

--- a/pages/change.php
+++ b/pages/change.php
@@ -63,18 +63,8 @@ if ( $newpassword != $confirmpassword ) { $result="nomatch"; }
 #==============================================================================
 # Check reCAPTCHA
 #==============================================================================
-if ( $result === "" ) {
-    if ( $use_recaptcha) {
-        $recaptcha = new \ReCaptcha\ReCaptcha($recaptcha_privatekey, is_null($recaptcha_request_method) ? null : new $recaptcha_request_method());
-        $resp = $recaptcha->verify($_POST['g-recaptcha-response'], $_SERVER['REMOTE_ADDR']);
-        if (!$resp->isSuccess()) {
-            $result = "badcaptcha";
-            error_log("Bad reCAPTCHA attempt with user $login");
-            foreach ($resp->getErrorCodes() as $code) {
-                error_log("reCAPTCHA error: $code");
-            }
-        }
-    }
+if ( $result === "" && $use_recaptcha ) {
+    $result = check_recaptcha($recaptcha_privatekey, $recaptcha_request_method, $_POST['g-recaptcha-response'], $login);
 }
 
 #==============================================================================

--- a/pages/changesshkey.php
+++ b/pages/changesshkey.php
@@ -57,7 +57,7 @@ if ( $result === "" ) {
 #==============================================================================
 if ( $result === "" ) {
     if ( $use_recaptcha) {
-        $recaptcha = new \ReCaptcha\ReCaptcha($recaptcha_privatekey);
+        $recaptcha = new \ReCaptcha\ReCaptcha($recaptcha_privatekey, is_null($recaptcha_request_method) ? null : new $recaptcha_request_method());
         $resp = $recaptcha->verify($_POST['g-recaptcha-response'], $_SERVER['REMOTE_ADDR']);
         if (!$resp->isSuccess()) {
             $result = "badcaptcha";

--- a/pages/changesshkey.php
+++ b/pages/changesshkey.php
@@ -55,18 +55,8 @@ if ( $result === "" ) {
 #==============================================================================
 # Check reCAPTCHA
 #==============================================================================
-if ( $result === "" ) {
-    if ( $use_recaptcha) {
-        $recaptcha = new \ReCaptcha\ReCaptcha($recaptcha_privatekey, is_null($recaptcha_request_method) ? null : new $recaptcha_request_method());
-        $resp = $recaptcha->verify($_POST['g-recaptcha-response'], $_SERVER['REMOTE_ADDR']);
-        if (!$resp->isSuccess()) {
-            $result = "badcaptcha";
-            error_log("Bad reCAPTCHA attempt with user $login");
-            foreach ($resp->getErrorCodes() as $code) {
-                error_log("reCAPTCHA error: $code");
-            }
-        }
-    }
+if ( $result === "" && $use_recaptcha ) {
+    $result = check_recaptcha($recaptcha_privatekey, $recaptcha_request_method, $_POST['g-recaptcha-response'], $login);
 }
 
 #==============================================================================

--- a/pages/resetbyquestions.php
+++ b/pages/resetbyquestions.php
@@ -66,7 +66,7 @@ if ( $result === "" ) {
 #==============================================================================
 if ( $result === "" ) {
     if ( $use_recaptcha ) {
-        $recaptcha = new \ReCaptcha\ReCaptcha($recaptcha_privatekey);
+        $recaptcha = new \ReCaptcha\ReCaptcha($recaptcha_privatekey, is_null($recaptcha_request_method) ? null : new $recaptcha_request_method());
         $resp = $recaptcha->verify($_POST['g-recaptcha-response'], $_SERVER['REMOTE_ADDR']);
         if (!$resp->isSuccess()) {
             $result = "badcaptcha";

--- a/pages/resetbyquestions.php
+++ b/pages/resetbyquestions.php
@@ -64,18 +64,8 @@ if ( $result === "" ) {
 #==============================================================================
 # Check reCAPTCHA
 #==============================================================================
-if ( $result === "" ) {
-    if ( $use_recaptcha ) {
-        $recaptcha = new \ReCaptcha\ReCaptcha($recaptcha_privatekey, is_null($recaptcha_request_method) ? null : new $recaptcha_request_method());
-        $resp = $recaptcha->verify($_POST['g-recaptcha-response'], $_SERVER['REMOTE_ADDR']);
-        if (!$resp->isSuccess()) {
-            $result = "badcaptcha";
-            error_log("Bad reCAPTCHA attempt with user $login");
-            foreach ($resp->getErrorCodes() as $code) {
-                error_log("reCAPTCHA error: $code");
-            }
-        }
-    }
+if ( $result === "" && $use_recaptcha ) {
+    $result = check_recaptcha($recaptcha_privatekey, $recaptcha_request_method, $_POST['g-recaptcha-response'], $login);
 }
 
 #==============================================================================

--- a/pages/resetbytoken.php
+++ b/pages/resetbytoken.php
@@ -102,7 +102,7 @@ if ( $result === "" ) {
 #==============================================================================
 if ( $result === "" ) {
     if ( $use_recaptcha ) {
-        $recaptcha = new \ReCaptcha\ReCaptcha($recaptcha_privatekey);
+        $recaptcha = new \ReCaptcha\ReCaptcha($recaptcha_privatekey, is_null($recaptcha_request_method) ? null : new $recaptcha_request_method());
         $resp = $recaptcha->verify($_POST['g-recaptcha-response'], $_SERVER['REMOTE_ADDR']);
         if (!$resp->isSuccess()) {
             $result = "badcaptcha";

--- a/pages/resetbytoken.php
+++ b/pages/resetbytoken.php
@@ -100,18 +100,8 @@ if ( $result === "" ) {
 #==============================================================================
 # Check reCAPTCHA
 #==============================================================================
-if ( $result === "" ) {
-    if ( $use_recaptcha ) {
-        $recaptcha = new \ReCaptcha\ReCaptcha($recaptcha_privatekey, is_null($recaptcha_request_method) ? null : new $recaptcha_request_method());
-        $resp = $recaptcha->verify($_POST['g-recaptcha-response'], $_SERVER['REMOTE_ADDR']);
-        if (!$resp->isSuccess()) {
-            $result = "badcaptcha";
-            error_log("Bad reCAPTCHA attempt with user $login");
-            foreach ($resp->getErrorCodes() as $code) {
-                error_log("reCAPTCHA error: $code");
-            }
-        }
-    }
+if ( $result === "" && $use_recaptcha ) {
+    $result = check_recaptcha($recaptcha_privatekey, $recaptcha_request_method, $_POST['g-recaptcha-response'], $login);
 }
 
 #==============================================================================

--- a/pages/sendsms.php
+++ b/pages/sendsms.php
@@ -116,7 +116,7 @@ if ( $result === "" ) {
 #==============================================================================
 if ( $result === "" ) {
     if ( $use_recaptcha ) {
-        $recaptcha = new \ReCaptcha\ReCaptcha($recaptcha_privatekey);
+        $recaptcha = new \ReCaptcha\ReCaptcha($recaptcha_privatekey, is_null($recaptcha_request_method) ? null : new $recaptcha_request_method());
         $resp = $recaptcha->verify($_POST['g-recaptcha-response'], $_SERVER['REMOTE_ADDR']);
         if (!$resp->isSuccess()) {
             $result = "badcaptcha";

--- a/pages/sendsms.php
+++ b/pages/sendsms.php
@@ -113,19 +113,8 @@ if ( $result === "" ) {
 
 #==============================================================================
 # Check reCAPTCHA
-#==============================================================================
-if ( $result === "" ) {
-    if ( $use_recaptcha ) {
-        $recaptcha = new \ReCaptcha\ReCaptcha($recaptcha_privatekey, is_null($recaptcha_request_method) ? null : new $recaptcha_request_method());
-        $resp = $recaptcha->verify($_POST['g-recaptcha-response'], $_SERVER['REMOTE_ADDR']);
-        if (!$resp->isSuccess()) {
-            $result = "badcaptcha";
-            error_log("Bad reCAPTCHA attempt with user $login");
-            foreach ($resp->getErrorCodes() as $code) {
-                error_log("reCAPTCHA error: $code");
-            }
-        }
-    }
+if ( $result === "" && $use_recaptcha ) {
+    $result = check_recaptcha($recaptcha_privatekey, $recaptcha_request_method, $_POST['g-recaptcha-response'], $login);
 }
 
 #==============================================================================

--- a/pages/sendtoken.php
+++ b/pages/sendtoken.php
@@ -55,7 +55,7 @@ if ( $result === "" ) {
 #==============================================================================
 if ( $result === "" ) {
     if ( $use_recaptcha ) {
-        $recaptcha = new \ReCaptcha\ReCaptcha($recaptcha_privatekey);
+        $recaptcha = new \ReCaptcha\ReCaptcha($recaptcha_privatekey, is_null($recaptcha_request_method) ? null : new $recaptcha_request_method());
         $resp = $recaptcha->verify($_POST['g-recaptcha-response'], $_SERVER['REMOTE_ADDR']);
         if (!$resp->isSuccess()) {
             $result = "badcaptcha";

--- a/pages/sendtoken.php
+++ b/pages/sendtoken.php
@@ -53,18 +53,8 @@ if ( $result === "" ) {
 #==============================================================================
 # Check reCAPTCHA
 #==============================================================================
-if ( $result === "" ) {
-    if ( $use_recaptcha ) {
-        $recaptcha = new \ReCaptcha\ReCaptcha($recaptcha_privatekey, is_null($recaptcha_request_method) ? null : new $recaptcha_request_method());
-        $resp = $recaptcha->verify($_POST['g-recaptcha-response'], $_SERVER['REMOTE_ADDR']);
-        if (!$resp->isSuccess()) {
-            $result = "badcaptcha";
-            error_log("Bad reCAPTCHA attempt with user $login");
-            foreach ($resp->getErrorCodes() as $code) {
-                error_log("reCAPTCHA error: $code");
-            }
-        }
-    }
+if ( $result === "" && $use_recaptcha ) {
+    $result = check_recaptcha($recaptcha_privatekey, $recaptcha_request_method, $_POST['g-recaptcha-response'], $login);
 }
 
 #==============================================================================

--- a/pages/setquestions.php
+++ b/pages/setquestions.php
@@ -60,7 +60,7 @@ if ( $result === "" ) {
 #==============================================================================
 if ( $result === "" ) {
     if ( $use_recaptcha) {
-        $recaptcha = new \ReCaptcha\ReCaptcha($recaptcha_privatekey);
+        $recaptcha = new \ReCaptcha\ReCaptcha($recaptcha_privatekey, is_null($recaptcha_request_method) ? null : new $recaptcha_request_method());
         $resp = $recaptcha->verify($_POST['g-recaptcha-response'], $_SERVER['REMOTE_ADDR']);
         if (!$resp->isSuccess()) {
             $result = "badcaptcha";

--- a/pages/setquestions.php
+++ b/pages/setquestions.php
@@ -58,18 +58,8 @@ if ( $result === "" ) {
 #==============================================================================
 # Check reCAPTCHA
 #==============================================================================
-if ( $result === "" ) {
-    if ( $use_recaptcha) {
-        $recaptcha = new \ReCaptcha\ReCaptcha($recaptcha_privatekey, is_null($recaptcha_request_method) ? null : new $recaptcha_request_method());
-        $resp = $recaptcha->verify($_POST['g-recaptcha-response'], $_SERVER['REMOTE_ADDR']);
-        if (!$resp->isSuccess()) {
-            $result = "badcaptcha";
-            error_log("Bad reCAPTCHA attempt with user $login");
-            foreach ($resp->getErrorCodes() as $code) {
-                error_log("reCAPTCHA error: $code");
-            }
-        }
-    }
+if ( $result === "" && $use_recaptcha ) {
+    $result = check_recaptcha($recaptcha_privatekey, $recaptcha_request_method, $_POST['g-recaptcha-response'], $login);
 }
 
 #==============================================================================

--- a/tests/ReCaptchaTest.php
+++ b/tests/ReCaptchaTest.php
@@ -1,0 +1,26 @@
+<?php
+
+require_once __DIR__ . '/../lib/vendor/autoload.php';
+
+class ReCaptchaTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Verifies that alternative request method is available (for $recaptcha_request_method in config)
+     * @dataProvider requestMethodsProvider
+     * @param $requestMethod string Request method FQCN
+     */
+    public function testRequestMethodAvailable($requestMethod)
+    {
+        $this->assertInstanceOf('\ReCaptcha\RequestMethod', new $requestMethod);
+    }
+
+    public function requestMethodsProvider()
+    {
+        return [
+            ['\ReCaptcha\RequestMethod\Post'], // default reCAPTCHA request method
+            ['\ReCaptcha\RequestMethod\SocketPost'],
+            ['\ReCaptcha\RequestMethod\CurlPost'],
+        ];
+    }
+}
+


### PR DESCRIPTION
Allow override of reCAPTCHA request method for environments where allow_url_fopen=0 cf https://github.com/ltb-project/self-service-password/issues/130

Also helpful if the server needs a proxy to access the internet (cf https://github.com/ltb-project/self-service-password/issues/126)

@jwacalex would you mind testing if this PR works on your environment ?

Please do not merge this PR yet, more testing needed.