### PR TITLE
Fix travis builds for php 7.0 and 7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ php:
 
 before_install:
   # If PHP >= 7.0, force use of PHPUnit 5.7
-  - if php -r "exit( (int)! version_compare( '$TRAVIS_PHP_VERSION', '7.0', '>=' ) );"; then mkdir ~/bin && wget -O ~/bin/phpunit https://phar.phpunit.de/phpunit-5.7.phar && chmod +x ~/bin/phpunit; fi
+  - if php -r "exit( (int)! version_compare( '$TRAVIS_PHP_VERSION', '7.0', '>=' ) );"; then mkdir -p ~/bin && wget -O ~/bin/phpunit https://phar.phpunit.de/phpunit-5.7.phar && chmod +x ~/bin/phpunit; fi
 
 script: phpunit tests
 


### PR DESCRIPTION
Travis trusty image changed a little bit when it turned stable.
This commit repairs broken builds on php 7.0 et 7.1

Last time we had problems with travis (hhvm was broken https://github.com/ltb-project/self-service-password/pull/118), precise was deprecated or EOL I do not remember good, and trusty was beta, imminent release. I verified SSP's .travis.yml on trusty and set it explicitely in the file.

Travis marked "trusty" as stable but published a slightly different image from the beta, it breaks the script that enables us to use the old version of phpunit on php 7.0, 7.1 because a folder is already created.