### PR TITLE
add ldap extended error

### DIFF
--- a/pages/change.php
+++ b/pages/change.php
@@ -19,6 +19,11 @@
 #
 #==============================================================================
 
+# define not available in php 5
+define("LDAP_OPT_DIAGNOSTIC_MESSAGE", 0x0032);
+
+
+
 # This page is called to change password
 
 #==============================================================================
@@ -190,6 +195,12 @@ if ( $result === "" ) {
         $command = escapeshellcmd($posthook).' '.escapeshellarg($login).' '.escapeshellarg($newpassword).' '.escapeshellarg($oldpassword);
         exec($command);
     }
+ 
+    $ldap_extended_error = "" ;
+    if ( $result === "passworderror" ) {
+      ldap_get_option($ldap, LDAP_OPT_DIAGNOSTIC_MESSAGE, $ldap_extended_error);
+   }
+
 }
 
 #==============================================================================
@@ -198,7 +209,7 @@ if ( $result === "" ) {
 ?>
 
 <div class="result alert alert-<?php echo get_criticity($result) ?>">
-<p><i class="fa fa-fw <?php echo get_fa_class($result) ?>" aria-hidden="true"></i> <?php echo $messages[$result]; ?></p>
+<p><i class="fa fa-fw <?php echo get_fa_class($result) ?>" aria-hidden="true"></i> <?php echo $messages[$result] . ":" . $ldap_extended_error ;  ?></p>
 </div>
 
 <?php if ( $result !== "passwordchanged" ) { ?>


### PR DESCRIPTION
Hi,

I use OpenLDAP with ppolicy.
When use self-password , and get error from openldap, cause of "password policy" into openldap, "self-password return only "Password was refused by the LDAP directory".

Could you get the extended error to be able to display the message coming from openldap ?

I do the following change into "change.php", but I suppose that I must do also "setquestions.php", "resetbytoken.php" and "resetbyquestions.php" ?