### PR TITLE
Remove obsolete stripslashes_if_gpc_magic_quotes

### DIFF
--- a/lib/functions.inc.php
+++ b/lib/functions.inc.php
@@ -141,16 +141,6 @@ function generate_sms_token( $sms_token_length ) {
     return $smstoken;
 }
 
-# Strip slashes added by PHP
-# Only if magic_quote_gpc is not set to off in php.ini
-function stripslashes_if_gpc_magic_quotes( $string ) {
-    if(get_magic_quotes_gpc()) {
-        return stripslashes($string);
-    } else {
-        return $string;
-    }
-}
-
 # Get message criticity
 function get_criticity( $msg ) {
 

--- a/pages/change.php
+++ b/pages/change.php
@@ -46,12 +46,6 @@ if (isset($_REQUEST["login"]) and $_REQUEST["login"]) { $login = $_REQUEST["logi
 if (! isset($_REQUEST["login"]) and ! isset($_POST["confirmpassword"]) and ! isset($_POST["newpassword"]) and ! isset($_POST["oldpassword"]))
  { $result = "emptychangeform"; }
 
-# Strip slashes added by PHP
-$login = stripslashes_if_gpc_magic_quotes($login);
-$oldpassword = stripslashes_if_gpc_magic_quotes($oldpassword);
-$newpassword = stripslashes_if_gpc_magic_quotes($newpassword);
-$confirmpassword = stripslashes_if_gpc_magic_quotes($confirmpassword);
-
 # Check the entered username for characters that our installation doesn't support
 if ( $result === "" ) {
     $result = check_username_validity($login,$login_forbidden_chars);

--- a/pages/changesshkey.php
+++ b/pages/changesshkey.php
@@ -42,11 +42,6 @@ if (isset($_REQUEST["login"]) and $_REQUEST["login"]) { $login = $_REQUEST["logi
 if (! isset($_REQUEST["login"]) and ! isset($_POST["password"]) and ! isset($_POST["sshkey"]))
  { $result = "emptysshkeychangeform"; }
 
-# Strip slashes added by PHP
-$login = stripslashes_if_gpc_magic_quotes($login);
-$password = stripslashes_if_gpc_magic_quotes($password);
-$sshkey = stripslashes_if_gpc_magic_quotes($sshkey);
-
 # Check the entered username for characters that our installation doesn't support
 if ( $result === "" ) {
     $result = check_username_validity($login,$login_forbidden_chars);

--- a/pages/resetbyquestions.php
+++ b/pages/resetbyquestions.php
@@ -49,13 +49,6 @@ if (isset($_REQUEST["login"]) and $_REQUEST["login"]) { $login = $_REQUEST["logi
 if (! isset($_POST["confirmpassword"]) and ! isset($_POST["newpassword"]) and ! isset($_POST["answer"]) and ! isset($_POST["question"]) and ! isset($_REQUEST["login"]))
  { $result = "emptyresetbyquestionsform"; }
 
-# Strip slashes added by PHP
-$login = stripslashes_if_gpc_magic_quotes($login);
-$question = stripslashes_if_gpc_magic_quotes($question);
-$answer = stripslashes_if_gpc_magic_quotes($answer);
-$newpassword = stripslashes_if_gpc_magic_quotes($newpassword);
-$confirmpassword = stripslashes_if_gpc_magic_quotes($confirmpassword);
-
 # Check the entered username for characters that our installation doesn't support
 if ( $result === "" ) {
     $result = check_username_validity($login,$login_forbidden_chars);

--- a/pages/resetbytoken.php
+++ b/pages/resetbytoken.php
@@ -91,10 +91,6 @@ if ( $result === "" ) {
      else { $result = "confirmpasswordrequired"; }
     if (isset($_POST["newpassword"]) and $_POST["newpassword"]) { $newpassword = $_POST["newpassword"]; }
      else { $result = "newpasswordrequired"; }
-
-    # Strip slashes added by PHP
-    $newpassword = stripslashes_if_gpc_magic_quotes($newpassword);
-    $confirmpassword = stripslashes_if_gpc_magic_quotes($confirmpassword);
 }
 
 #==============================================================================

--- a/pages/sendsms.php
+++ b/pages/sendsms.php
@@ -103,9 +103,6 @@ if (!$crypt_tokens) {
     $result = "emptysendsmsform";
 }
 
-# Strip slashes added by PHP
-$login = stripslashes_if_gpc_magic_quotes($login);
-
 # Check the entered username for characters that our installation doesn't support
 if ( $result === "" ) {
     $result = check_username_validity($login,$login_forbidden_chars);

--- a/pages/sendtoken.php
+++ b/pages/sendtoken.php
@@ -41,10 +41,6 @@ if (isset($_REQUEST["login"]) and $_REQUEST["login"]) { $login = $_REQUEST["logi
 if (! isset($_POST["mail"]) and ! isset($_REQUEST["login"]))
  { $result = "emptysendtokenform"; }
 
-# Strip slashes added by PHP
-$login = stripslashes_if_gpc_magic_quotes($login);
-$mail = stripslashes_if_gpc_magic_quotes($mail);
-
 # Check the entered username for characters that our installation doesn't support
 if ( $result === "" ) {
     $result = check_username_validity($login,$login_forbidden_chars);

--- a/pages/setquestions.php
+++ b/pages/setquestions.php
@@ -44,12 +44,6 @@ if (isset($_REQUEST["login"]) and $_REQUEST["login"]) { $login = $_REQUEST["logi
 if (! isset($_POST["answer"]) and ! isset($_POST["question"]) and ! isset($_POST["password"]) and ! isset($_REQUEST["login"]))
  { $result = "emptysetquestionsform"; }
 
-# Strip slashes added by PHP
-$login = stripslashes_if_gpc_magic_quotes($login);
-$password = stripslashes_if_gpc_magic_quotes($password);
-$question = stripslashes_if_gpc_magic_quotes($question);
-$answer = stripslashes_if_gpc_magic_quotes($answer);
-
 # Check the entered username for characters that our installation doesn't support
 if ( $result === "" ) {
     $result = check_username_validity($login,$login_forbidden_chars);


### PR DESCRIPTION
Please remove magic quotes support, it is obsolete/removed since php 5.4.

If some users want to use the code en PHP 5.3, which I do not recommend because we do not test + this php version is no more secure + ssp only work partially on this version. Let them set magic quotes = off in their php.ini.

Keeping these functions is harmful to SSP's future