### PR TITLE
When debug = true, give a lot of ldap logs

### DIFF
--- a/index.php
+++ b/index.php
@@ -41,7 +41,10 @@ require_once("lib/vendor/PHPMailer/PHPMailerAutoload.php");
 # Error reporting
 #==============================================================================
 error_reporting(0);
-if($debug) error_reporting(E_ALL);
+if($debug) {
+    error_reporting(E_ALL);
+    ldap_set_option(NULL, LDAP_OPT_DEBUG_LEVEL, 7);
+}
 
 #==============================================================================
 # Language

--- a/index.php
+++ b/index.php
@@ -43,6 +43,7 @@ require_once("lib/vendor/PHPMailer/PHPMailerAutoload.php");
 error_reporting(0);
 if($debug) {
     error_reporting(E_ALL);
+    // Important to get error details in case of SSL/TLS failure at connection
     ldap_set_option(NULL, LDAP_OPT_DEBUG_LEVEL, 7);
 }
 


### PR DESCRIPTION
Currently users can have hard time installing SSP on windows because php ldap configuration is not intuitive. 
Also, it is difficult to know when installing ssp if the ldap server is refusing the connection or if it is simply not available on the network, at least for openldap.

More detailed logs will help users to better diagnose their problems.

Sample logs at connection from windows.
```
ldap_url_parse_ext(ldap://localhost/)
ldap_init: trying c:\openldap\sysconf\ldap.conf
ldap_init: HOME env is NULL
ldap_init: trying ldaprc
ldap_init: LDAPCONF env is NULL
ldap_init: LDAPRC env is NULL
ldap_create
ldap_url_parse_ext(ldap://localhost:10389)
ldap_sasl_bind_s
ldap_sasl_bind
ldap_send_initial_request
ldap_new_connection 1 1 0
ldap_int_open_connection
ldap_connect_to_host: TCP localhost:10389
ldap_new_socket: 708
ldap_prepare_socket: 708
ldap_connect_to_host: Trying 127.0.0.1:10389
ldap_pvt_connect: fd: 708 tm: -1 async: 0
attempting to connect:
connect success
ldap_open_defconn: successful
ldap_send_server_request
ldap_result ld 000002C081C74860 msgid 1
wait4msg ld 000002C081C74860 msgid 1 (infinite timeout)
wait4msg continue ld 000002C081C74860 msgid 1 all 1
** ld 000002C081C74860 Connections:
* host: localhost  port: 10389  (default)
  refcnt: 2  status: Connected
  last used: Sat Dec  2 16:17:08 2017

```