### PR TITLE
Fix "SSH Key required" message wrong color when ssh key is not submitted

### DIFF
--- a/lib/functions.inc.php
+++ b/lib/functions.inc.php
@@ -148,7 +148,7 @@ function get_criticity( $msg ) {
     return "danger";
     }
 
-    if ( preg_match( "/(login|oldpassword|newpassword|confirmpassword|answer|question|password|mail|token)required|badcaptcha|tokenattempts/" , $msg ) ) {
+    if ( preg_match( "/(login|oldpassword|newpassword|confirmpassword|answer|question|password|mail|token|sshkey)required|badcaptcha|tokenattempts/" , $msg ) ) {
         return "warning";
     }
 


### PR DESCRIPTION
Minor cosmetic fix when change ssh key form is submitted and the field is not filled