### PR TITLE
Strict checking of input parameter values

### DIFF
--- a/pages/change.php
+++ b/pages/change.php
@@ -35,6 +35,13 @@ $userdn = "";
 if (!isset($pwd_forbidden_chars)) { $pwd_forbidden_chars=""; }
 $mail = "";
 
+##verify that variables are strings
+
+if (isset($_POST["confirmpassword"]) and !is_string($_POST["confirmpassword"])) {return;}  
+if (isset($_POST["newpassword"]) and !is_string($_POST["newpassword"])) {return;} 
+if (isset($_POST["oldpassword"]) and !is_string($_POST["oldpassword"])) {return ;}
+if (isset($_REQUEST["login"]) and !is_string($_REQUEST["login"])) {return;}
+
 if (isset($_POST["confirmpassword"]) and $_POST["confirmpassword"]) { $confirmpassword = $_POST["confirmpassword"]; }
  else { $result = "confirmpasswordrequired"; }
 if (isset($_POST["newpassword"]) and $_POST["newpassword"]) { $newpassword = $_POST["newpassword"]; }


### PR DESCRIPTION
Need to check that the login, the newpassword, comfirmpassword and oldpassword given by the user have the right type (in this case: strings) before  going any further, to avoid issues with ldap_bind(). 
