### PR TITLE
Remove annoying warnings

### DIFF
--- a/index.php
+++ b/index.php
@@ -114,6 +114,7 @@ if ( ! in_array($action, $available_actions) ) { $action = $default_action; }
 
 # Get source for menu
 if (isset($_REQUEST["source"]) and $_REQUEST["source"]) { $source = $_REQUEST["source"]; }
+else { $source="unknown"; }
 
 #==============================================================================
 # Other default values

--- a/pages/change.php
+++ b/pages/change.php
@@ -190,7 +190,7 @@ if ( in_array($result, $obscure_failure_messages) ) { $result = "badcredentials"
 <p><i class="fa fa-fw <?php echo get_fa_class($result) ?>" aria-hidden="true"></i> <?php echo $messages[$result]; ?></p>
 </div>
 
-<?php if ( $display_posthook_error and $posthook_return > 0 ) { ?>
+<?php if ( isset($posthook_return) and $display_posthook_error and $posthook_return > 0 ) { ?>
 
 <div class="result alert alert-warning">
 <p><i class="fa fa-fw fa-exclamation-triangle" aria-hidden="true"></i> <?php echo $posthook_output[0]; ?></p>


### PR DESCRIPTION
Just adding simple tests to avoid "PHP Notice:  Undefined variable:" in logs