### PR TITLE
Fix in_array() error

### DIFF
--- a/pages/change.php
+++ b/pages/change.php
@@ -183,7 +183,7 @@ if ( $result === "" ) {
 #==============================================================================
 # HTML
 #==============================================================================
-if ( in_array($result, $obscure_failure_messages) ) { $result = "badcredentials"; }
+if ( in_array($result, array($obscure_failure_messages)) ) { $result = "badcredentials"; }
 ?>
 
 <div class="result alert alert-<?php echo get_criticity($result) ?>">

--- a/pages/changesshkey.php
+++ b/pages/changesshkey.php
@@ -140,7 +140,7 @@ if ( $result === "" ) {
 #==============================================================================
 # HTML
 #==============================================================================
-if ( in_array($result, $obscure_failure_messages) ) { $result = "badcredentials"; }
+if ( in_array($result, array($obscure_failure_messages)) ) { $result = "badcredentials"; }
 ?>
 
 <div class="result alert alert-<?php echo get_criticity($result) ?>">

--- a/pages/resetbyquestions.php
+++ b/pages/resetbyquestions.php
@@ -177,7 +177,7 @@ if ($result === "") {
 #==============================================================================
 # HTML
 #==============================================================================
-if ( in_array($result, $obscure_failure_messages) ) { $result = "badcredentials"; }
+if ( in_array($result, array($obscure_failure_messages)) ) { $result = "badcredentials"; }
 ?>
 
 <div class="result alert alert-<?php echo get_criticity($result) ?>">

--- a/pages/resetbytoken.php
+++ b/pages/resetbytoken.php
@@ -199,7 +199,7 @@ if ( $result === "passwordchanged" ) {
 #==============================================================================
 # HTML
 #==============================================================================
-if ( in_array($result, $obscure_failure_messages) ) { $result = "badcredentials"; }
+if ( in_array($result, array($obscure_failure_messages)) ) { $result = "badcredentials"; }
 ?>
 
 <div class="result alert alert-<?php echo get_criticity($result) ?>">

--- a/pages/sendsms.php
+++ b/pages/sendsms.php
@@ -315,7 +315,7 @@ if ( $result === "redirect" ) {
 #==============================================================================
 # HTML
 #==============================================================================
-if ( in_array($result, $obscure_failure_messages) ) { $result = "badcredentials"; }
+if ( in_array($result, array($obscure_failure_messages)) ) { $result = "badcredentials"; }
 ?>
 
 <div class="result alert alert-<?php echo get_criticity($result) ?>">

--- a/pages/sendtoken.php
+++ b/pages/sendtoken.php
@@ -209,7 +209,7 @@ if ( $result === "" ) {
 #==============================================================================
 # HTML
 #==============================================================================
-if ( in_array($result, $obscure_failure_messages) ) { $result = "badcredentials"; }
+if ( in_array($result, array($obscure_failure_messages)) ) { $result = "badcredentials"; }
 ?>
 
 <div class="result alert alert-<?php echo get_criticity($result) ?>">

--- a/pages/setquestions.php
+++ b/pages/setquestions.php
@@ -168,7 +168,7 @@ if ( $result === "" ) {
 #==============================================================================
 # HTML
 #==============================================================================
-if ( in_array($result, $obscure_failure_messages) ) { $result = "badcredentials"; }
+if ( in_array($result, array($obscure_failure_messages)) ) { $result = "badcredentials"; }
 ?>
 
 <div class="result alert alert-<?php echo get_criticity($result) ?>">


### PR DESCRIPTION
In 6bc80dafa1292d76745ff509692530ee2438fa76 the
$obscure_failure_messages option was added but it doesn't have any
default value so it defaults to null. in_array() expects the second
parameter to be an array, so we explicity cast it to an array in the
event it hasn't been set or hasn't been set as an array.

This fixes the following warning:
PHP Warning: in_array() expects parameter 2 to be array, null given
in /usr/share/self-service-password/pages/sendtoken.php on line 212

Note that this notice still exists so, $obscure_failure_messages should
probably also be initialized to something valid:
PHP Notice:  Undefined variable: obscure_failure_messages in
/usr/share/self-service-password/pages/sendtoken.php on line 212