### PR TITLE
Add base64 encoding option to passwords in posthook commands

### DIFF
--- a/conf/config.inc.php
+++ b/conf/config.inc.php
@@ -299,6 +299,9 @@ $default_action = "change";
 # Launch a posthook script after successful password change
 #$posthook = "/usr/share/self-service-password/posthook.sh";
 #$display_posthook_error = true;
+# Encode passwords sent to posthook script as base64. This will prevent alteration of the passwords if set to true.
+# To read the actual password in the posthook script, use a base64_decode function/tool
+#$posthook_password_encodebase64 = false;
 
 # Hide some messages to not disclose sensitive information
 # These messages will be replaced by badcredentials error

--- a/lib/functions.inc.php
+++ b/lib/functions.inc.php
@@ -558,7 +558,7 @@ function check_recaptcha($recaptcha_privatekey, $recaptcha_request_method, $resp
 
     return '';
 }
-/* @function string posthook_command(string $posthook, string  $login, string $newpassword, null|string $oldpassword, null|boolean $posthook_password_encodebase64, null|boolean $use_oldpass)
+/* @function string posthook_command(string $posthook, string  $login, string $newpassword, null|string $oldpassword, null|boolean $posthook_password_encodebase64)
    Creates the command line to execute for the posthook process. Passwords will be base64 encoded if configured. Base64 encoding will prevent passwords with special 
    characters to be modified by the escapeshellarg() function.
    @param $postkook string script/command to execute for procesing posthook data
@@ -566,22 +566,22 @@ function check_recaptcha($recaptcha_privatekey, $recaptcha_request_method, $resp
    @param $newpassword string new passwword for given login
    @param $oldpassword string old password for given login
    @param posthook_password_encodebase64 boolean set to true if passwords are to be converted to base64 encoded strings
-   @param use_oldpass boolean set to true if user is changing a password, or false if resetting
 */
-function posthook_command($posthook, $login, $newpassword, $oldpassword = null, $posthook_password_encodebase64 = false, $use_oldpass = false) {
+function posthook_command($posthook, $login, $newpassword, $oldpassword = null, $posthook_password_encodebase64 = false) {
 
 	$command = '';
 	if ( isset($posthook_password_encodebase64) && $posthook_password_encodebase64 ) {
-		if ( $use_oldpass ) {
-			$command = escapeshellcmd($posthook).' '.escapeshellarg($login).' '.base64_encode($newpassword).' '.base64_encode($oldpassword);
-		} else {
-			$command = escapeshellcmd($posthook).' '.escapeshellarg($login).' '.base64_encode($newpassword);
+		$command = escapeshellcmd($posthook).' '.escapeshellarg($login).' '.base64_encode($newpassword);
+
+		if ( ! is_null($oldpassword) ) {
+			$command .= ' '.base64_encode($oldpassword);		
 		}
-	} else {
-		if ( $use_oldpass ) {
-			return $command = escapeshellcmd($posthook).' '.escapeshellarg($login).' '.escapeshellarg($newpassword).' '.escapeshellarg($oldpassword);
-		} else {
-			$command = escapeshellcmd($posthook).' '.escapeshellarg($login).' '.escapeshellarg($newpassword);
+
+	} else {		
+		$command = escapeshellcmd($posthook).' '.escapeshellarg($login).' '.escapeshellarg($newpassword);		
+
+		if ( ! is_null($oldpassword) ) {
+			$command .= ' '.escapeshellarg($oldpassword);		
 		}
 	}
 	return $command;

--- a/lib/functions.inc.php
+++ b/lib/functions.inc.php
@@ -558,3 +558,31 @@ function check_recaptcha($recaptcha_privatekey, $recaptcha_request_method, $resp
 
     return '';
 }
+/* @function string posthook_command(string $posthook, string  $login, string $newpassword, null|string $oldpassword, null|boolean $posthook_password_encodebase64, null|boolean $use_oldpass)
+   Creates the command line to execute for the posthook process. Passwords will be base64 encoded if configured. Base64 encoding will prevent passwords with special 
+   characters to be modified by the escapeshellarg() function.
+   @param $postkook string script/command to execute for procesing posthook data
+   @param $login string username to change/set password for
+   @param $newpassword string new passwword for given login
+   @param $oldpassword string old password for given login
+   @param posthook_password_encodebase64 boolean set to true if passwords are to be converted to base64 encoded strings
+   @param use_oldpass boolean set to true if user is changing a password, or false if resetting
+*/
+function posthook_command($posthook, $login, $newpassword, $oldpassword = null, $posthook_password_encodebase64 = false, $use_oldpass = false) {
+
+	$command = '';
+	if ( isset($posthook_password_encodebase64) && $posthook_password_encodebase64 ) {
+		if ( $use_oldpass ) {
+			$command = escapeshellcmd($posthook).' '.escapeshellarg($login).' '.base64_encode($newpassword).' '.base64_encode($oldpassword);
+		} else {
+			$command = escapeshellcmd($posthook).' '.escapeshellarg($login).' '.base64_encode($newpassword);
+		}
+	} else {
+		if ( $use_oldpass ) {
+			return $command = escapeshellcmd($posthook).' '.escapeshellarg($login).' '.escapeshellarg($newpassword).' '.escapeshellarg($oldpassword);
+		} else {
+			$command = escapeshellcmd($posthook).' '.escapeshellarg($login).' '.escapeshellarg($newpassword);
+		}
+	}
+	return $command;
+}

--- a/pages/change.php
+++ b/pages/change.php
@@ -175,7 +175,7 @@ if ( $result === "" ) {
 if ( $result === "" ) {
     $result = change_password($ldap, $userdn, $newpassword, $ad_mode, $ad_options, $samba_mode, $samba_options, $shadow_options, $hash, $hash_options, $who_change_password, $oldpassword);
     if ( $result === "passwordchanged" && isset($posthook) ) {
-        $command = posthook_command($posthook, $login, $newpassword, $oldpassword, $posthook_password_encodebase64, true);
+        $command = posthook_command($posthook, $login, $newpassword, $oldpassword, $posthook_password_encodebase64);
         exec($command, $posthook_output, $posthook_return);
     }
 }

--- a/pages/change.php
+++ b/pages/change.php
@@ -175,7 +175,7 @@ if ( $result === "" ) {
 if ( $result === "" ) {
     $result = change_password($ldap, $userdn, $newpassword, $ad_mode, $ad_options, $samba_mode, $samba_options, $shadow_options, $hash, $hash_options, $who_change_password, $oldpassword);
     if ( $result === "passwordchanged" && isset($posthook) ) {
-        $command = escapeshellcmd($posthook).' '.escapeshellarg($login).' '.escapeshellarg($newpassword).' '.escapeshellarg($oldpassword);
+        $command = posthook_command($posthook, $login, $newpassword, $oldpassword, $posthook_password_encodebase64, true);
         exec($command, $posthook_output, $posthook_return);
     }
 }

--- a/pages/resetbyquestions.php
+++ b/pages/resetbyquestions.php
@@ -169,7 +169,7 @@ if ( $result === "" ) {
 if ($result === "") {
     $result = change_password($ldap, $userdn, $newpassword, $ad_mode, $ad_options, $samba_mode, $samba_options, $shadow_options, $hash, $hash_options, "", "");
     if ( $result === "passwordchanged" && isset($posthook) ) {
-        $command = escapeshellcmd($posthook).' '.escapeshellarg($login).' '.escapeshellarg($newpassword);
+        $command = posthook_command($posthook, $login, $newpassword, null, $posthook_password_encodebase64, false);
         exec($command, $posthook_output, $posthook_return);
     }
 }

--- a/pages/resetbyquestions.php
+++ b/pages/resetbyquestions.php
@@ -169,7 +169,7 @@ if ( $result === "" ) {
 if ($result === "") {
     $result = change_password($ldap, $userdn, $newpassword, $ad_mode, $ad_options, $samba_mode, $samba_options, $shadow_options, $hash, $hash_options, "", "");
     if ( $result === "passwordchanged" && isset($posthook) ) {
-        $command = posthook_command($posthook, $login, $newpassword, null, $posthook_password_encodebase64, false);
+        $command = posthook_command($posthook, $login, $newpassword, null, $posthook_password_encodebase64);
         exec($command, $posthook_output, $posthook_return);
     }
 }

--- a/pages/resetbytoken.php
+++ b/pages/resetbytoken.php
@@ -185,7 +185,7 @@ if ( $result === "" ) {
 if ($result === "") {
     $result = change_password($ldap, $userdn, $newpassword, $ad_mode, $ad_options, $samba_mode, $samba_options, $shadow_options, $hash, $hash_options, "", "");
     if ( $result === "passwordchanged" && isset($posthook) ) {
-        $command = escapeshellcmd($posthook).' '.escapeshellarg($login).' '.escapeshellarg($newpassword);
+        $command = posthook_command($posthook, $login, $newpassword, null, $posthook_password_encodebase64, false);
         exec($command, $posthook_output, $posthook_return);
     }
 }

--- a/pages/resetbytoken.php
+++ b/pages/resetbytoken.php
@@ -185,7 +185,7 @@ if ( $result === "" ) {
 if ($result === "") {
     $result = change_password($ldap, $userdn, $newpassword, $ad_mode, $ad_options, $samba_mode, $samba_options, $shadow_options, $hash, $hash_options, "", "");
     if ( $result === "passwordchanged" && isset($posthook) ) {
-        $command = posthook_command($posthook, $login, $newpassword, null, $posthook_password_encodebase64, false);
+        $command = posthook_command($posthook, $login, $newpassword, null, $posthook_password_encodebase64);
         exec($command, $posthook_output, $posthook_return);
     }
 }


### PR DESCRIPTION
This change will allow the posthook script to handle passwords with characters
that would normally be escaped, rendering a different password to what was
actually entered by the user. Posthook script will have to handle decoding of
base64 strings.

- New true/false config option: $posthook_password_encodebase64
- New function posthook_command($posthook, $login, $newpassword, $oldpassword = null, $posthook_password_encodebase64 = false, $use_oldpass = false)