### PR TITLE
add policy: disallow special character at beginning or end

### DIFF
--- a/conf/config.inc.php
+++ b/conf/config.inc.php
@@ -121,6 +121,9 @@ $pwd_show_policy = "never";
 # below - the form
 $pwd_show_policy_pos = "above";
 
+# disallow use of the only special character as defined in `$pwd_special_chars` at the beginning and end
+$pwd_no_special_at_ends = false;
+
 # Who changes the password?
 # Also applicable for question/answer save
 # user: the user itself

--- a/index.php
+++ b/index.php
@@ -140,7 +140,8 @@ $pwd_policy_config = array(
     "pwd_no_reuse"            => $pwd_no_reuse,
     "pwd_diff_login"          => $pwd_diff_login,
     "pwd_complexity"          => $pwd_complexity,
-    "use_pwnedpasswords"      => $use_pwnedpasswords
+    "use_pwnedpasswords"      => $use_pwnedpasswords,
+    "pwd_no_special_at_ends"  => $pwd_no_special_at_ends
 );
 
 if (!isset($pwd_show_policy_pos)) { $pwd_show_policy_pos = "above"; }

--- a/lang/ca.inc.php
+++ b/lang/ca.inc.php
@@ -135,3 +135,5 @@ $messages['changesshkeyhelp'] = "Introduïu la contrasenya i la clau SSH.";
 $messages['changesshkeymessage'] = "Hola {login},\n\nLa claus SSH s'ha canviat.\n\nSi no va iniciar aquest canvi, poseu-vos en contacte amb l'administrador immediatament.";
 $messages['pwned'] = "Your new password has already been published on leaks, you should consider changing it on any other service that it is in use";
 $messages['policypwned'] = "Your new password may not be published on any previous public password leak from any site";
+$messages['specialatends'] = "Your new password has its only special character at the beginning or end";
+$messages['policyspecialatends'] = "Your new password may not have its only special character at the beginning or end";

--- a/lang/cn.inc.php
+++ b/lang/cn.inc.php
@@ -131,3 +131,5 @@ $messages['changesshkeymessage'] = "您好{login},\n\n您的SSH金钥已变更�
 $messages['changesshkeyhelp'] = "输入您的密码和新的SSH密钥。";
 $messages['pwned'] = "Your new password has already been published on leaks, you should consider changing it on any other service that it is in use";
 $messages['policypwned'] = "Your new password may not be published on any previous public password leak from any site";
+$messages['specialatends'] = "Your new password has its only special character at the beginning or end";
+$messages['policyspecialatends'] = "Your new password may not have its only special character at the beginning or end";

--- a/lang/cs.inc.php
+++ b/lang/cs.inc.php
@@ -131,3 +131,5 @@ $messages['sshkey'] = "SSH klíč";
 $messages['menusshkey'] = "SSH klíč";
 $messages['pwned'] = "Your new password has already been published on leaks, you should consider changing it on any other service that it is in use";
 $messages['policypwned'] = "Your new password may not be published on any previous public password leak from any site";
+$messages['specialatends'] = "Your new password has its only special character at the beginning or end";
+$messages['policyspecialatends'] = "Your new password may not have its only special character at the beginning or end";

--- a/lang/de.inc.php
+++ b/lang/de.inc.php
@@ -133,3 +133,5 @@ $messages['menusshkey'] = "SSH Schlüssel";
 $messages['changesshkeysubject'] = "Ihr SSH-Schlüssel wurde geändert";
 $messages['pwned'] = "Your new password has already been published on leaks, you should consider changing it on any other service that it is in use";
 $messages['policypwned'] = "Your new password may not be published on any previous public password leak from any site";
+$messages['specialatends'] = "Dein Passwort enthält das einzige Sonderzeichen am Anfang oder am Ende";
+$messages['policyspecialatends'] = "Ein Sonderzeichen, wenn es nur ein einziges gibt, darf nicht am Anfang oder am Ende stehen";

--- a/lang/ee.inc.php
+++ b/lang/ee.inc.php
@@ -133,3 +133,5 @@ $messages['sameaslogin'] = "Uus parool kattub kasutajanimega";
 $messages['policydifflogin'] = "Uus parool ei tohi kattuda kasutajanimega";
 $messages['pwned'] = "Your new password has already been published on leaks, you should consider changing it on any other service that it is in use";
 $messages['policypwned'] = "Your new password may not be published on any previous public password leak from any site";
+$messages['specialatends'] = "Your new password has its only special character at the beginning or end";
+$messages['policyspecialatends'] = "Your new password may not have its only special character at the beginning or end";

--- a/lang/el.inc.php
+++ b/lang/el.inc.php
@@ -131,3 +131,5 @@ $messages['changehelpsshkey'] = "<a href=\"?action=changesshkey\">Αλλάξτε
 $messages['sshkey'] = "SSH Key";
 $messages['pwned'] = "Your new password has already been published on leaks, you should consider changing it on any other service that it is in use";
 $messages['policypwned'] = "Your new password may not be published on any previous public password leak from any site";
+$messages['specialatends'] = "Your new password has its only special character at the beginning or end";
+$messages['policyspecialatends'] = "Your new password may not have its only special character at the beginning or end";

--- a/lang/en.inc.php
+++ b/lang/en.inc.php
@@ -131,3 +131,5 @@ $messages['sameaslogin'] = "Your new password is identical to your login";
 $messages['policydifflogin'] = "Your new password may not be the same as your login";
 $messages['pwned'] = "Your new password has already been published on leaks, you should consider changing it on any other service that it is in use";
 $messages['policypwned'] = "Your new password may not be published on any previous public password leak from any site";
+$messages['specialatends'] = "Your new password has its only special character at the beginning or end";
+$messages['policyspecialatends'] = "Your new password may not have its only special character at the beginning or end";

--- a/lang/es.inc.php
+++ b/lang/es.inc.php
@@ -132,3 +132,5 @@ $messages['changesshkeyhelp'] = "Introduzca su contraseña y la nueva clave SSH.
 $messages['sshkeyerror'] = "La clave SSH fue rechazada por el directorio LDAP";
 $messages['pwned'] = "Su contraseña ha sido publicada en listas de contraseñas publicas, por lo cual ha sido rechazada, deberia considerar cambiarla en cualquer otro sitio que la haya usado";
 $messages['policypwned'] = "Su contraseña no puede haber sido publicada previamente en ninguna lista de contraseñas filtradas accesible al publico de ningun sitio";
+$messages['specialatends'] = "Your new password has its only special character at the beginning or end";
+$messages['policyspecialatends'] = "Your new password may not have its only special character at the beginning or end";

--- a/lang/fr.inc.php
+++ b/lang/fr.inc.php
@@ -131,3 +131,5 @@ $messages['changesshkeyhelp'] = "Entrez votre mot de passe et la nouvelle clé S
 $messages['sshkeyerror'] = "La clé SSH a été refusée par l'annuaire  LDAP";
 $messages['pwned'] = "Your new password has already been published on leaks, you should consider changing it on any other service that it is in use";
 $messages['policypwned'] = "Your new password may not be published on any previous public password leak from any site";
+$messages['specialatends'] = "Your new password has its only special character at the beginning or end";
+$messages['policyspecialatends'] = "Your new password may not have its only special character at the beginning or end";

--- a/lang/hu.inc.php
+++ b/lang/hu.inc.php
@@ -131,3 +131,5 @@ $messages['changesshkeyhelp'] = "Írja be a jelszót és az új SSH kulcs.";
 $messages['sshkeyerror'] = "Az LDAP könyvtár elutasította az SSH kulcsot";
 $messages['pwned'] = "Your new password has already been published on leaks, you should consider changing it on any other service that it is in use";
 $messages['policypwned'] = "Your new password may not be published on any previous public password leak from any site";
+$messages['specialatends'] = "Your new password has its only special character at the beginning or end";
+$messages['policyspecialatends'] = "Your new password may not have its only special character at the beginning or end";

--- a/lang/it.inc.php
+++ b/lang/it.inc.php
@@ -131,3 +131,5 @@ $messages['changesshkeyhelp'] = "Inserire la password e la nuova chiave SSH.";
 $messages['sshkeyerror'] = "SSH Key è stata rifiutata dalla directory LDAP";
 $messages['pwned'] = "Your new password has already been published on leaks, you should consider changing it on any other service that it is in use";
 $messages['policypwned'] = "Your new password may not be published on any previous public password leak from any site";
+$messages['specialatends'] = "Your new password has its only special character at the beginning or end";
+$messages['policyspecialatends'] = "Your new password may not have its only special character at the beginning or end";

--- a/lang/ja.inc.php
+++ b/lang/ja.inc.php
@@ -131,3 +131,5 @@ $messages['changesshkeyhelp'] = "パスワードと新しいSSHキーを入力�
 $messages['sshkeyerror'] = "SSHキーがLDAPディレクトリによって拒否されました";
 $messages['pwned'] = "Your new password has already been published on leaks, you should consider changing it on any other service that it is in use";
 $messages['policypwned'] = "Your new password may not be published on any previous public password leak from any site";
+$messages['specialatends'] = "Your new password has its only special character at the beginning or end";
+$messages['policyspecialatends'] = "Your new password may not have its only special character at the beginning or end";

--- a/lang/nb-NO.inc.php
+++ b/lang/nb-NO.inc.php
@@ -131,3 +131,5 @@ $messages['changesshkeyhelp'] = "Angi ditt passord og ny SSH-nøkkel.";
 $messages['sshkeyerror'] = "SSH nøkkel er ikke godkjent av LDAP-katalogen";
 $messages['pwned'] = "Ditt nye passord har allerede blitt publisert på passord-leaks siter. Du bør derfor vurdere å endre dette passordet og passord for andre siter hvor det samme passordet er benyttet.";
 $messages['policypwned'] = "Ditt nye passord er ikke publisert på kjente passord-leak siter";
+$messages['specialatends'] = "Your new password has its only special character at the beginning or end";
+$messages['policyspecialatends'] = "Your new password may not have its only special character at the beginning or end";

--- a/lang/nl.inc.php
+++ b/lang/nl.inc.php
@@ -133,3 +133,5 @@ $messages['changesshkeyhelp'] = "Voer uw wachtwoord in en nieuwe SSH sleutel.";
 $messages['sshkeyerror'] = "SSH sleutel werd geweigerd door de LDAP-directory";
 $messages['pwned'] = "Your new password has already been published on leaks, you should consider changing it on any other service that it is in use";
 $messages['policypwned'] = "Your new password may not be published on any previous public password leak from any site";
+$messages['specialatends'] = "Your new password has its only special character at the beginning or end";
+$messages['policyspecialatends'] = "Your new password may not have its only special character at the beginning or end";

--- a/lang/pl.inc.php
+++ b/lang/pl.inc.php
@@ -133,3 +133,5 @@ $messages['changesshkeyhelp'] = "Wprowadź swoje hasło i nowy klucz SSH.";
 $messages['sshkeyerror'] = "SSH Key został odrzucony przez katalogu LDAP";
 $messages['pwned'] = "Your new password has already been published on leaks, you should consider changing it on any other service that it is in use";
 $messages['policypwned'] = "Your new password may not be published on any previous public password leak from any site";
+$messages['specialatends'] = "Your new password has its only special character at the beginning or end";
+$messages['policyspecialatends'] = "Your new password may not have its only special character at the beginning or end";

--- a/lang/pt-BR.inc.php
+++ b/lang/pt-BR.inc.php
@@ -131,3 +131,5 @@ $messages['changesshkeyhelp'] = "Digite sua senha e a nova chave SSH.";
 $messages['sshkeyerror'] = "A chave SSH foi recusada pelo diretório LDAP";
 $messages['pwned'] = "Sua nova senha já foi publicada como vazada, você deveria alterá-la em qualquer outro site que a utilize.";
 $messages['policypwned'] = "Parece que sua nova senha não foi publicada como vazada de qualquer site";
+$messages['specialatends'] = "Your new password has its only special character at the beginning or end";
+$messages['policyspecialatends'] = "Your new password may not have its only special character at the beginning or end";

--- a/lang/pt-PT.inc.php
+++ b/lang/pt-PT.inc.php
@@ -131,3 +131,5 @@ $messages['changesshkeyhelp'] = "Digite sua senha e a nova chave SSH.";
 $messages['sshkeyerror'] = "A chave SSH foi recusada pelo diretório LDAP";
 $messages['pwned'] = "Your new password has already been published on leaks, you should consider changing it on any other service that it is in use";
 $messages['policypwned'] = "Your new password may not be published on any previous public password leak from any site";
+$messages['specialatends'] = "Your new password has its only special character at the beginning or end";
+$messages['policyspecialatends'] = "Your new password may not have its only special character at the beginning or end";

--- a/lang/ru.inc.php
+++ b/lang/ru.inc.php
@@ -131,3 +131,5 @@ $messages['changesshkeyhelp'] = "Введите свой пароль и нов�
 $messages['sshkeyerror'] = "Ключ SSH был отклонен каталогом LDAP";
 $messages['pwned'] = "Your new password has already been published on leaks, you should consider changing it on any other service that it is in use";
 $messages['policypwned'] = "Your new password may not be published on any previous public password leak from any site";
+$messages['specialatends'] = "Your new password has its only special character at the beginning or end";
+$messages['policyspecialatends'] = "Your new password may not have its only special character at the beginning or end";

--- a/lang/sk.inc.php
+++ b/lang/sk.inc.php
@@ -131,3 +131,5 @@ $messages['changesshkeyhelp'] = "Zadajte heslo a nové SSH kľúč.";
 $messages['sshkeyerror'] = "SSH kľúč bol odmietnutý v adresári LDAP";
 $messages['pwned'] = "Your new password has already been published on leaks, you should consider changing it on any other service that it is in use";
 $messages['policypwned'] = "Your new password may not be published on any previous public password leak from any site";
+$messages['specialatends'] = "Your new password has its only special character at the beginning or end";
+$messages['policyspecialatends'] = "Your new password may not have its only special character at the beginning or end";

--- a/lang/sl.inc.php
+++ b/lang/sl.inc.php
@@ -131,3 +131,5 @@ $messages['changesshkeyhelp'] = "Vnesite geslo in nov ključ SSH.";
 $messages['sshkeyerror'] = "SSH Ključna je bila zavrnjena z imeniku LDAP";
 $messages['pwned'] = "Your new password has already been published on leaks, you should consider changing it on any other service that it is in use";
 $messages['policypwned'] = "Your new password may not be published on any previous public password leak from any site";
+$messages['specialatends'] = "Your new password has its only special character at the beginning or end";
+$messages['policyspecialatends'] = "Your new password may not have its only special character at the beginning or end";

--- a/lang/sv.inc.php
+++ b/lang/sv.inc.php
@@ -131,3 +131,5 @@ $messages['changesshkeyhelp'] = "Ange ditt lösenord och ny SSH-nyckel.";
 $messages['sshkeyerror'] = "SSH Key avslogs av LDAP-katalogen";
 $messages['pwned'] = "Your new password has already been published on leaks, you should consider changing it on any other service that it is in use";
 $messages['policypwned'] = "Your new password may not be published on any previous public password leak from any site";
+$messages['specialatends'] = "Your new password has its only special character at the beginning or end";
+$messages['policyspecialatends'] = "Your new password may not have its only special character at the beginning or end";

--- a/lang/tr.inc.php
+++ b/lang/tr.inc.php
@@ -131,3 +131,5 @@ $messages['changesshkeyhelp'] = "Parolanızı ve yeni SSH anahtarınızı girin.
 $messages['sshkeyerror'] = "SSH Anahtarı LDAP dizini tarafından reddedildi";
 $messages['pwned'] = "Your new password has already been published on leaks, you should consider changing it on any other service that it is in use";
 $messages['policypwned'] = "Your new password may not be published on any previous public password leak from any site";
+$messages['specialatends'] = "Your new password has its only special character at the beginning or end";
+$messages['policyspecialatends'] = "Your new password may not have its only special character at the beginning or end";

--- a/lang/uk.inc.php
+++ b/lang/uk.inc.php
@@ -132,3 +132,5 @@ $messages['changesshkeyhelp'] = "Введіть свій пароль і нов�
 $messages['sshkeyerror'] = "SSH Key була відхилена каталогом LDAP";
 $messages['pwned'] = "Your new password has already been published on leaks, you should consider changing it on any other service that it is in use";
 $messages['policypwned'] = "Your new password may not be published on any previous public password leak from any site";
+$messages['specialatends'] = "Your new password has its only special character at the beginning or end";
+$messages['policyspecialatends'] = "Your new password may not have its only special character at the beginning or end";

--- a/lang/zh-CN.inc.php
+++ b/lang/zh-CN.inc.php
@@ -131,3 +131,5 @@ $messages['sameaslogin'] = "您的新密码与您的用户名相同";
 $messages['policydifflogin'] = "您的新密码不能与您的用户名相同";
 $messages['pwned'] = "Your new password has already been published on leaks, you should consider changing it on any other service that it is in use";
 $messages['policypwned'] = "Your new password may not be published on any previous public password leak from any site";
+$messages['specialatends'] = "Your new password has its only special character at the beginning or end";
+$messages['policyspecialatends'] = "Your new password may not have its only special character at the beginning or end";

--- a/lang/zh-TW.inc.php
+++ b/lang/zh-TW.inc.php
@@ -131,3 +131,5 @@ $messages['sameaslogin'] = "您的新密碼與您的帳號相同";
 $messages['policydifflogin'] = "您的新密碼不可以與您的帳號相同";
 $messages['pwned'] = "Your new password has already been published on leaks, you should consider changing it on any other service that it is in use";
 $messages['policypwned'] = "Your new password may not be published on any previous public password leak from any site";
+$messages['specialatends'] = "Your new password has its only special character at the beginning or end";
+$messages['policyspecialatends'] = "Your new password may not have its only special character at the beginning or end";

--- a/lib/functions.inc.php
+++ b/lib/functions.inc.php
@@ -192,6 +192,7 @@ function show_policy( $messages, $pwd_policy_config, $result ) {
     if ( $pwd_no_reuse        ) { echo "<li>".$messages["policynoreuse"]                                 ."\n"; }
     if ( $pwd_diff_login      ) { echo "<li>".$messages["policydifflogin"]                               ."\n"; }
     if ( $use_pwnedpasswords  ) { echo "<li>".$messages["policypwned"]                               ."\n"; }
+    if ( $pwd_no_special_at_ends  ) { echo "<li>".$messages["policyspecialatends"] ."</li>\n"; }
     echo "</ul>\n";
     echo "</div>\n";
 }
@@ -212,9 +213,13 @@ function check_password_strength( $password, $oldpassword, $pwd_policy_config, $
     $digit = count( $digit_res[0] );
 
     $special = 0;
+    $special_at_ends = false;
     if ( isset($pwd_special_chars) && !empty($pwd_special_chars) ) {
         preg_match_all("/[$pwd_special_chars]/", $password, $special_res);
         $special = count( $special_res[0] );
+        if ( $pwd_no_special_at_ends ) {
+          $special_at_ends = preg_match("/(^[$pwd_special_chars]|[$pwd_special_chars]$)/", $password, $special_res);
+        }
     }
 
     $forbidden = 0;
@@ -253,6 +258,9 @@ function check_password_strength( $password, $oldpassword, $pwd_policy_config, $
 
     # Forbidden chars
     if ( $forbidden > 0 ) { $result="forbiddenchars"; }
+
+    # Special chars at beginning or end
+    if ( $special_at_ends > 0 && $special == 1 ) { $result="specialatends"; }
 
     # Same as old password?
     if ( $pwd_no_reuse and $password === $oldpassword ) { $result="sameasold"; }

--- a/tests/CheckPasswordTest.php
+++ b/tests/CheckPasswordTest.php
@@ -27,7 +27,8 @@ class CheckPasswordTest extends \PHPUnit_Framework_TestCase
             "pwd_no_reuse"            => true,
             "pwd_diff_login"          => true,
             "pwd_complexity"          => 0,
-            "use_pwnedpasswords"      => false
+            "use_pwnedpasswords"      => false,
+            "pwd_no_special_at_ends"  => false,
         );
 
         $login = "coudot";
@@ -56,11 +57,16 @@ class CheckPasswordTest extends \PHPUnit_Framework_TestCase
             "pwd_no_reuse"            => true,
             "pwd_diff_login"          => true,
             "pwd_complexity"          => 3,
-            "use_pwnedpasswords"      => false
+            "use_pwnedpasswords"      => false,
+            "pwd_no_special_at_ends"  => true,
         );
 
         $this->assertEquals("notcomplex", check_password_strength( "simple", $oldpassword, $pwd_policy_config, $login ) );
+        $this->assertEquals("specialatends", check_password_strength( "!simple", $oldpassword, $pwd_policy_config, $login ) );
+        $this->assertEquals("specialatends", check_password_strength( "simple?", $oldpassword, $pwd_policy_config, $login ) );
         $this->assertEquals("", check_password_strength( "C0mplex", $oldpassword, $pwd_policy_config, $login ) );
+        $this->assertEquals("", check_password_strength( "C0!mplex", $oldpassword, $pwd_policy_config, $login ) );
+        $this->assertEquals("", check_password_strength( "%C0!mplex", $oldpassword, $pwd_policy_config, $login ) );
 
     }
 
@@ -91,7 +97,8 @@ class CheckPasswordTest extends \PHPUnit_Framework_TestCase
             "pwd_no_reuse"            => true,
             "pwd_diff_login"          => true,
             "pwd_complexity"          => 0,
-            "use_pwnedpasswords"      => true
+            "use_pwnedpasswords"      => true,
+            "pwd_no_special_at_ends"  => false,
         );
 
         $this->assertEquals("pwned", check_password_strength( "!1Password", $oldpassword, $pwd_policy_config, $login ) );


### PR DESCRIPTION
It's a common strategy for users to fulfill the "special char" requirement by just appending a special char to the password.

This policy prevents this by checking if there is exactly 1 special character used and if it is at the beginning or end.