### PR TITLE
New policy: Forbidden words

### DIFF
--- a/conf/config.inc.php
+++ b/conf/config.inc.php
@@ -107,6 +107,8 @@ $pwd_special_chars = "^a-zA-Z0-9";
 $pwd_no_reuse = true;
 # Check that password is different than login
 $pwd_diff_login = true;
+# Forbidden words which must not appear in the password
+$pwd_forbidden_words = array();
 # Complexity: number of different class of character required
 $pwd_complexity = 0;
 # use pwnedpasswords api v2 to securely check if the password has been on a leak

--- a/index.php
+++ b/index.php
@@ -141,7 +141,8 @@ $pwd_policy_config = array(
     "pwd_diff_login"          => $pwd_diff_login,
     "pwd_complexity"          => $pwd_complexity,
     "use_pwnedpasswords"      => $use_pwnedpasswords,
-    "pwd_no_special_at_ends"  => $pwd_no_special_at_ends
+    "pwd_no_special_at_ends"  => $pwd_no_special_at_ends,
+    "pwd_forbidden_words"     => $pwd_forbidden_words,
 );
 
 if (!isset($pwd_show_policy_pos)) { $pwd_show_policy_pos = "above"; }

--- a/lang/ca.inc.php
+++ b/lang/ca.inc.php
@@ -137,3 +137,5 @@ $messages['pwned'] = "Your new password has already been published on leaks, you
 $messages['policypwned'] = "Your new password may not be published on any previous public password leak from any site";
 $messages['specialatends'] = "Your new password has its only special character at the beginning or end";
 $messages['policyspecialatends'] = "Your new password may not have its only special character at the beginning or end";
+$messages['forbiddenwords'] = "Your passwords contains forbidden words or strings";
+$messages['policyforbiddenwords'] = "Your password must not contain:";

--- a/lang/cn.inc.php
+++ b/lang/cn.inc.php
@@ -133,3 +133,5 @@ $messages['pwned'] = "Your new password has already been published on leaks, you
 $messages['policypwned'] = "Your new password may not be published on any previous public password leak from any site";
 $messages['specialatends'] = "Your new password has its only special character at the beginning or end";
 $messages['policyspecialatends'] = "Your new password may not have its only special character at the beginning or end";
+$messages['forbiddenwords'] = "Your passwords contains forbidden words or strings";
+$messages['policyforbiddenwords'] = "Your password must not contain:";

--- a/lang/cs.inc.php
+++ b/lang/cs.inc.php
@@ -133,3 +133,5 @@ $messages['pwned'] = "Your new password has already been published on leaks, you
 $messages['policypwned'] = "Your new password may not be published on any previous public password leak from any site";
 $messages['specialatends'] = "Your new password has its only special character at the beginning or end";
 $messages['policyspecialatends'] = "Your new password may not have its only special character at the beginning or end";
+$messages['forbiddenwords'] = "Your passwords contains forbidden words or strings";
+$messages['policyforbiddenwords'] = "Your password must not contain:";

--- a/lang/de.inc.php
+++ b/lang/de.inc.php
@@ -135,3 +135,5 @@ $messages['pwned'] = "Your new password has already been published on leaks, you
 $messages['policypwned'] = "Your new password may not be published on any previous public password leak from any site";
 $messages['specialatends'] = "Dein Passwort enthält das einzige Sonderzeichen am Anfang oder am Ende";
 $messages['policyspecialatends'] = "Ein Sonderzeichen, wenn es nur ein einziges gibt, darf nicht am Anfang oder am Ende stehen";
+$messages['forbiddenwords'] = "Ihr Passwort enthält verbotene Worte oder Zeichenketten";
+$messages['policyforbiddenwords'] = "Ihr Passwort darf nicht enthalten:";

--- a/lang/ee.inc.php
+++ b/lang/ee.inc.php
@@ -135,3 +135,5 @@ $messages['pwned'] = "Your new password has already been published on leaks, you
 $messages['policypwned'] = "Your new password may not be published on any previous public password leak from any site";
 $messages['specialatends'] = "Your new password has its only special character at the beginning or end";
 $messages['policyspecialatends'] = "Your new password may not have its only special character at the beginning or end";
+$messages['forbiddenwords'] = "Your passwords contains forbidden words or strings";
+$messages['policyforbiddenwords'] = "Your password must not contain:";

--- a/lang/el.inc.php
+++ b/lang/el.inc.php
@@ -133,3 +133,5 @@ $messages['pwned'] = "Your new password has already been published on leaks, you
 $messages['policypwned'] = "Your new password may not be published on any previous public password leak from any site";
 $messages['specialatends'] = "Your new password has its only special character at the beginning or end";
 $messages['policyspecialatends'] = "Your new password may not have its only special character at the beginning or end";
+$messages['forbiddenwords'] = "Your passwords contains forbidden words or strings";
+$messages['policyforbiddenwords'] = "Your password must not contain:";

--- a/lang/en.inc.php
+++ b/lang/en.inc.php
@@ -133,3 +133,5 @@ $messages['pwned'] = "Your new password has already been published on leaks, you
 $messages['policypwned'] = "Your new password may not be published on any previous public password leak from any site";
 $messages['specialatends'] = "Your new password has its only special character at the beginning or end";
 $messages['policyspecialatends'] = "Your new password may not have its only special character at the beginning or end";
+$messages['forbiddenwords'] = "Your passwords contains forbidden words or strings";
+$messages['policyforbiddenwords'] = "Your password must not contain:";

--- a/lang/es.inc.php
+++ b/lang/es.inc.php
@@ -134,3 +134,5 @@ $messages['pwned'] = "Su contraseña ha sido publicada en listas de contraseñas
 $messages['policypwned'] = "Su contraseña no puede haber sido publicada previamente en ninguna lista de contraseñas filtradas accesible al publico de ningun sitio";
 $messages['specialatends'] = "Your new password has its only special character at the beginning or end";
 $messages['policyspecialatends'] = "Your new password may not have its only special character at the beginning or end";
+$messages['forbiddenwords'] = "Your passwords contains forbidden words or strings";
+$messages['policyforbiddenwords'] = "Your password must not contain:";

--- a/lang/fr.inc.php
+++ b/lang/fr.inc.php
@@ -133,3 +133,5 @@ $messages['pwned'] = "Your new password has already been published on leaks, you
 $messages['policypwned'] = "Your new password may not be published on any previous public password leak from any site";
 $messages['specialatends'] = "Your new password has its only special character at the beginning or end";
 $messages['policyspecialatends'] = "Your new password may not have its only special character at the beginning or end";
+$messages['forbiddenwords'] = "Your passwords contains forbidden words or strings";
+$messages['policyforbiddenwords'] = "Your password must not contain:";

--- a/lang/hu.inc.php
+++ b/lang/hu.inc.php
@@ -133,3 +133,5 @@ $messages['pwned'] = "Your new password has already been published on leaks, you
 $messages['policypwned'] = "Your new password may not be published on any previous public password leak from any site";
 $messages['specialatends'] = "Your new password has its only special character at the beginning or end";
 $messages['policyspecialatends'] = "Your new password may not have its only special character at the beginning or end";
+$messages['forbiddenwords'] = "Your passwords contains forbidden words or strings";
+$messages['policyforbiddenwords'] = "Your password must not contain:";

--- a/lang/it.inc.php
+++ b/lang/it.inc.php
@@ -133,3 +133,5 @@ $messages['pwned'] = "Your new password has already been published on leaks, you
 $messages['policypwned'] = "Your new password may not be published on any previous public password leak from any site";
 $messages['specialatends'] = "Your new password has its only special character at the beginning or end";
 $messages['policyspecialatends'] = "Your new password may not have its only special character at the beginning or end";
+$messages['forbiddenwords'] = "Your passwords contains forbidden words or strings";
+$messages['policyforbiddenwords'] = "Your password must not contain:";

--- a/lang/ja.inc.php
+++ b/lang/ja.inc.php
@@ -133,3 +133,5 @@ $messages['pwned'] = "Your new password has already been published on leaks, you
 $messages['policypwned'] = "Your new password may not be published on any previous public password leak from any site";
 $messages['specialatends'] = "Your new password has its only special character at the beginning or end";
 $messages['policyspecialatends'] = "Your new password may not have its only special character at the beginning or end";
+$messages['forbiddenwords'] = "Your passwords contains forbidden words or strings";
+$messages['policyforbiddenwords'] = "Your password must not contain:";

--- a/lang/nb-NO.inc.php
+++ b/lang/nb-NO.inc.php
@@ -133,3 +133,5 @@ $messages['pwned'] = "Ditt nye passord har allerede blitt publisert på passord-
 $messages['policypwned'] = "Ditt nye passord er ikke publisert på kjente passord-leak siter";
 $messages['specialatends'] = "Your new password has its only special character at the beginning or end";
 $messages['policyspecialatends'] = "Your new password may not have its only special character at the beginning or end";
+$messages['forbiddenwords'] = "Your passwords contains forbidden words or strings";
+$messages['policyforbiddenwords'] = "Your password must not contain:";

--- a/lang/nl.inc.php
+++ b/lang/nl.inc.php
@@ -135,3 +135,5 @@ $messages['pwned'] = "Your new password has already been published on leaks, you
 $messages['policypwned'] = "Your new password may not be published on any previous public password leak from any site";
 $messages['specialatends'] = "Your new password has its only special character at the beginning or end";
 $messages['policyspecialatends'] = "Your new password may not have its only special character at the beginning or end";
+$messages['forbiddenwords'] = "Your passwords contains forbidden words or strings";
+$messages['policyforbiddenwords'] = "Your password must not contain:";

--- a/lang/pl.inc.php
+++ b/lang/pl.inc.php
@@ -135,3 +135,5 @@ $messages['pwned'] = "Your new password has already been published on leaks, you
 $messages['policypwned'] = "Your new password may not be published on any previous public password leak from any site";
 $messages['specialatends'] = "Your new password has its only special character at the beginning or end";
 $messages['policyspecialatends'] = "Your new password may not have its only special character at the beginning or end";
+$messages['forbiddenwords'] = "Your passwords contains forbidden words or strings";
+$messages['policyforbiddenwords'] = "Your password must not contain:";

--- a/lang/pt-BR.inc.php
+++ b/lang/pt-BR.inc.php
@@ -133,3 +133,5 @@ $messages['pwned'] = "Sua nova senha já foi publicada como vazada, você deveri
 $messages['policypwned'] = "Parece que sua nova senha não foi publicada como vazada de qualquer site";
 $messages['specialatends'] = "Your new password has its only special character at the beginning or end";
 $messages['policyspecialatends'] = "Your new password may not have its only special character at the beginning or end";
+$messages['forbiddenwords'] = "Your passwords contains forbidden words or strings";
+$messages['policyforbiddenwords'] = "Your password must not contain:";

--- a/lang/pt-PT.inc.php
+++ b/lang/pt-PT.inc.php
@@ -133,3 +133,5 @@ $messages['pwned'] = "Your new password has already been published on leaks, you
 $messages['policypwned'] = "Your new password may not be published on any previous public password leak from any site";
 $messages['specialatends'] = "Your new password has its only special character at the beginning or end";
 $messages['policyspecialatends'] = "Your new password may not have its only special character at the beginning or end";
+$messages['forbiddenwords'] = "Your passwords contains forbidden words or strings";
+$messages['policyforbiddenwords'] = "Your password must not contain:";

--- a/lang/ru.inc.php
+++ b/lang/ru.inc.php
@@ -133,3 +133,5 @@ $messages['pwned'] = "Your new password has already been published on leaks, you
 $messages['policypwned'] = "Your new password may not be published on any previous public password leak from any site";
 $messages['specialatends'] = "Your new password has its only special character at the beginning or end";
 $messages['policyspecialatends'] = "Your new password may not have its only special character at the beginning or end";
+$messages['forbiddenwords'] = "Your passwords contains forbidden words or strings";
+$messages['policyforbiddenwords'] = "Your password must not contain:";

--- a/lang/sk.inc.php
+++ b/lang/sk.inc.php
@@ -133,3 +133,5 @@ $messages['pwned'] = "Your new password has already been published on leaks, you
 $messages['policypwned'] = "Your new password may not be published on any previous public password leak from any site";
 $messages['specialatends'] = "Your new password has its only special character at the beginning or end";
 $messages['policyspecialatends'] = "Your new password may not have its only special character at the beginning or end";
+$messages['forbiddenwords'] = "Your passwords contains forbidden words or strings";
+$messages['policyforbiddenwords'] = "Your password must not contain:";

--- a/lang/sl.inc.php
+++ b/lang/sl.inc.php
@@ -133,3 +133,5 @@ $messages['pwned'] = "Your new password has already been published on leaks, you
 $messages['policypwned'] = "Your new password may not be published on any previous public password leak from any site";
 $messages['specialatends'] = "Your new password has its only special character at the beginning or end";
 $messages['policyspecialatends'] = "Your new password may not have its only special character at the beginning or end";
+$messages['forbiddenwords'] = "Your passwords contains forbidden words or strings";
+$messages['policyforbiddenwords'] = "Your password must not contain:";

--- a/lang/sv.inc.php
+++ b/lang/sv.inc.php
@@ -133,3 +133,5 @@ $messages['pwned'] = "Your new password has already been published on leaks, you
 $messages['policypwned'] = "Your new password may not be published on any previous public password leak from any site";
 $messages['specialatends'] = "Your new password has its only special character at the beginning or end";
 $messages['policyspecialatends'] = "Your new password may not have its only special character at the beginning or end";
+$messages['forbiddenwords'] = "Your passwords contains forbidden words or strings";
+$messages['policyforbiddenwords'] = "Your password must not contain:";

--- a/lang/tr.inc.php
+++ b/lang/tr.inc.php
@@ -133,3 +133,5 @@ $messages['pwned'] = "Your new password has already been published on leaks, you
 $messages['policypwned'] = "Your new password may not be published on any previous public password leak from any site";
 $messages['specialatends'] = "Your new password has its only special character at the beginning or end";
 $messages['policyspecialatends'] = "Your new password may not have its only special character at the beginning or end";
+$messages['forbiddenwords'] = "Your passwords contains forbidden words or strings";
+$messages['policyforbiddenwords'] = "Your password must not contain:";

--- a/lang/uk.inc.php
+++ b/lang/uk.inc.php
@@ -134,3 +134,5 @@ $messages['pwned'] = "Your new password has already been published on leaks, you
 $messages['policypwned'] = "Your new password may not be published on any previous public password leak from any site";
 $messages['specialatends'] = "Your new password has its only special character at the beginning or end";
 $messages['policyspecialatends'] = "Your new password may not have its only special character at the beginning or end";
+$messages['forbiddenwords'] = "Your passwords contains forbidden words or strings";
+$messages['policyforbiddenwords'] = "Your password must not contain:";

--- a/lang/zh-CN.inc.php
+++ b/lang/zh-CN.inc.php
@@ -133,3 +133,5 @@ $messages['pwned'] = "Your new password has already been published on leaks, you
 $messages['policypwned'] = "Your new password may not be published on any previous public password leak from any site";
 $messages['specialatends'] = "Your new password has its only special character at the beginning or end";
 $messages['policyspecialatends'] = "Your new password may not have its only special character at the beginning or end";
+$messages['forbiddenwords'] = "Your passwords contains forbidden words or strings";
+$messages['policyforbiddenwords'] = "Your password must not contain:";

--- a/lang/zh-TW.inc.php
+++ b/lang/zh-TW.inc.php
@@ -133,3 +133,5 @@ $messages['pwned'] = "Your new password has already been published on leaks, you
 $messages['policypwned'] = "Your new password may not be published on any previous public password leak from any site";
 $messages['specialatends'] = "Your new password has its only special character at the beginning or end";
 $messages['policyspecialatends'] = "Your new password may not have its only special character at the beginning or end";
+$messages['forbiddenwords'] = "Your passwords contains forbidden words or strings";
+$messages['policyforbiddenwords'] = "Your password must not contain:";

--- a/lib/functions.inc.php
+++ b/lib/functions.inc.php
@@ -144,7 +144,7 @@ function generate_sms_token( $sms_token_length ) {
 # Get message criticity
 function get_criticity( $msg ) {
 
-    if ( preg_match( "/nophpldap|phpupgraderequired|nophpmhash|nokeyphrase|ldaperror|nomatch|badcredentials|passworderror|tooshort|toobig|minlower|minupper|mindigit|minspecial|forbiddenchars|sameasold|answermoderror|answernomatch|mailnomatch|tokennotsent|tokennotvalid|notcomplex|smsnonumber|smscrypttokensrequired|nophpmbstring|nophpxml|smsnotsent|sameaslogin|pwned|sshkeyerror/" , $msg ) ) {
+    if ( preg_match( "/nophpldap|phpupgraderequired|nophpmhash|nokeyphrase|ldaperror|nomatch|badcredentials|passworderror|tooshort|toobig|minlower|minupper|mindigit|minspecial|forbiddenchars|sameasold|answermoderror|answernomatch|mailnomatch|tokennotsent|tokennotvalid|notcomplex|smsnonumber|smscrypttokensrequired|nophpmbstring|nophpxml|smsnotsent|sameaslogin|pwned|sshkeyerror|forbiddenwords/" , $msg ) ) {
     return "danger";
     }
 
@@ -174,7 +174,7 @@ function show_policy( $messages, $pwd_policy_config, $result ) {
     # Should we display it?
     if ( !$pwd_show_policy or $pwd_show_policy === "never" ) { return; }
     if ( $pwd_show_policy === "onerror" ) {
-        if ( !preg_match( "/tooshort|toobig|minlower|minupper|mindigit|minspecial|forbiddenchars|sameasold|notcomplex|sameaslogin|pwned/" , $result) ) { return; }
+        if ( !preg_match( "/tooshort|toobig|minlower|minupper|mindigit|minspecial|forbiddenchars|sameasold|notcomplex|sameaslogin|pwned|forbiddenwords/" , $result) ) { return; }
     }
 
     # Display bloc
@@ -193,6 +193,7 @@ function show_policy( $messages, $pwd_policy_config, $result ) {
     if ( $pwd_diff_login      ) { echo "<li>".$messages["policydifflogin"]                               ."\n"; }
     if ( $use_pwnedpasswords  ) { echo "<li>".$messages["policypwned"]                               ."\n"; }
     if ( $pwd_no_special_at_ends  ) { echo "<li>".$messages["policyspecialatends"] ."</li>\n"; }
+    if ( !empty($pwd_forbidden_words)) { echo "<li>".$messages["policyforbiddenwords"] ." " . implode(', ', $pwd_forbidden_words) ."</li>\n"; }
     echo "</ul>\n";
     echo "</div>\n";
 }
@@ -267,6 +268,16 @@ function check_password_strength( $password, $oldpassword, $pwd_policy_config, $
 
     # Same as login?
     if ( $pwd_diff_login and $password === $login ) { $result="sameaslogin"; }
+    
+    # Contains forbidden words?
+    if ( !empty($pwd_forbidden_words) ) { 
+      foreach( $pwd_forbidden_words as $disallowed ) {
+        if( stripos($password, $disallowed) !== false ) {
+          $result="forbiddenwords"; 
+          break;
+        }
+      }
+    }
 	
 	# pwned?
 	if ($use_pwnedpasswords) {

--- a/tests/CheckPasswordTest.php
+++ b/tests/CheckPasswordTest.php
@@ -29,6 +29,7 @@ class CheckPasswordTest extends \PHPUnit_Framework_TestCase
             "pwd_complexity"          => 0,
             "use_pwnedpasswords"      => false,
             "pwd_no_special_at_ends"  => false,
+            "pwd_forbidden_words"     => array(),
         );
 
         $login = "coudot";
@@ -59,11 +60,15 @@ class CheckPasswordTest extends \PHPUnit_Framework_TestCase
             "pwd_complexity"          => 3,
             "use_pwnedpasswords"      => false,
             "pwd_no_special_at_ends"  => true,
+            "pwd_forbidden_words"     => array('companyname', 'trademark'),
         );
 
         $this->assertEquals("notcomplex", check_password_strength( "simple", $oldpassword, $pwd_policy_config, $login ) );
         $this->assertEquals("specialatends", check_password_strength( "!simple", $oldpassword, $pwd_policy_config, $login ) );
         $this->assertEquals("specialatends", check_password_strength( "simple?", $oldpassword, $pwd_policy_config, $login ) );
+        $this->assertEquals("forbiddenwords", check_password_strength( "companyname", $oldpassword, $pwd_policy_config, $login ) );
+        $this->assertEquals("forbiddenwords", check_password_strength( "trademark", $oldpassword, $pwd_policy_config, $login ) );
+        $this->assertEquals("forbiddenwords", check_password_strength( "working at companyname is fun", $oldpassword, $pwd_policy_config, $login ) );
         $this->assertEquals("", check_password_strength( "C0mplex", $oldpassword, $pwd_policy_config, $login ) );
         $this->assertEquals("", check_password_strength( "C0!mplex", $oldpassword, $pwd_policy_config, $login ) );
         $this->assertEquals("", check_password_strength( "%C0!mplex", $oldpassword, $pwd_policy_config, $login ) );
@@ -99,6 +104,7 @@ class CheckPasswordTest extends \PHPUnit_Framework_TestCase
             "pwd_complexity"          => 0,
             "use_pwnedpasswords"      => true,
             "pwd_no_special_at_ends"  => false,
+            "pwd_forbidden_words"     => array(),
         );
 
         $this->assertEquals("pwned", check_password_strength( "!1Password", $oldpassword, $pwd_policy_config, $login ) );


### PR DESCRIPTION
Depending on the context or domain, there may be words which are more likely to be used by users in their passwords. This policy prevents that passwords contain any of the strings defined in `$pwd_forbidden_words`.