### PR TITLE
add support for setting multiple question/answers.

### DIFF
--- a/pages/setquestions.php
+++ b/pages/setquestions.php
@@ -153,10 +153,12 @@ if ( $result === "" ) {
     $answer_value = '{'.$question.'}'.$answer;
     $i = 0;
     $answers[$i++] = $crypt_answers ? encrypt($answer_value, $keyphrase) : $answer_value;
+    # Do we need to process multiple answers on this request?
     if ($aValues != NULL && $multiple_answers == true ) {
         #  Now determine if this answer has already been registered. If yes, don't add to the answer array.
         $question = preg_quote($question,'/');
         $pattern  = "/^\{$question\}(.*)$/i";
+        # Examine each previous question registered and look for matches.
         foreach ( $aValues as $key => $answer_encrypt ) {
             $value = $crypt_answers ? decrypt($answer_encrypt, $keyphrase) : $answer_encrypt;
             if (!preg_match($pattern, $value)) {

--- a/pages/setquestions.php
+++ b/pages/setquestions.php
@@ -151,23 +151,21 @@ if ( $result === "" ) {
     }
 
     $answer_value = '{'.$question.'}'.$answer;
-    $userdata[$answer_attribute] = $crypt_answers ? encrypt($answer_value, $keyphrase) : $answer_value;
-    
+    $i = 0;
+    $answers[$i++] = $crypt_answers ? encrypt($answer_value, $keyphrase) : $answer_value;
     if ($aValues != NULL ) {
-        // Now determine if this answer has already been registered. If yes, remove, before adding new answer.
-        $match = false;
+        #  Now determine if this answer has already been registered. If yes, don't add to the answer array.
         $question = preg_quote($question,'/');
-        $answer   = preg_quote($answer,'/');
         $pattern  = "/^\{$question\}(.*)$/i";
         foreach ( $aValues as $key => $answer_encrypt ) {
             $value = $crypt_answers ? decrypt($answer_encrypt, $keyphrase) : $answer_encrypt;
-            if (preg_match($pattern, $value)) {
-                $deldata[$answer_attribute] = $answer_encrypt;
-                $del = ldap_mod_del($ldap, $userdn , $deldata);
+            if (!preg_match($pattern, $value)) {
+                $answers[$i++] = $answer_encrypt;
             }
         }
-    }        
-    $add = ldap_mod_add($ldap, $userdn , $userdata);
+    }
+    $userdata[$answer_attribute] = $answers;
+    $replace = ldap_mod_replace($ldap, $userdn , $userdata);
     $errno = ldap_errno($ldap);
     if ( $errno ) {
         $result = "answermoderror";

--- a/pages/setquestions.php
+++ b/pages/setquestions.php
@@ -153,7 +153,7 @@ if ( $result === "" ) {
     $answer_value = '{'.$question.'}'.$answer;
     $i = 0;
     $answers[$i++] = $crypt_answers ? encrypt($answer_value, $keyphrase) : $answer_value;
-    if ($aValues != NULL ) {
+    if ($aValues != NULL && $multiple_answers == true ) {
         #  Now determine if this answer has already been registered. If yes, don't add to the answer array.
         $question = preg_quote($question,'/');
         $pattern  = "/^\{$question\}(.*)$/i";

--- a/pages/setquestions.php
+++ b/pages/setquestions.php
@@ -88,7 +88,7 @@ if ( $result === "" ) {
     # Search for user
     $ldap_filter = str_replace("{login}", $login, $ldap_filter);
     $search = ldap_search($ldap, $ldap_base, $ldap_filter);
-    
+
     $errno = ldap_errno($ldap);
     if ( $errno ) {
         $result = "ldaperror";
@@ -103,7 +103,7 @@ if ( $result === "" ) {
         $result = "badcredentials";
         error_log("LDAP - User $login not found");
     } else {
-    
+
     # Bind with password
     $bind = ldap_bind($ldap, $userdn, $password);
     if ( !$bind ) {
@@ -125,8 +125,8 @@ if ( $result === "" ) {
     }
 
     # Check objectClass presence and pull back previous answers.
-    $search = ldap_search($ldap, $userdn, "(objectClass=*)", array("objectClass", $answer_attribute) );
- 
+    $search = ldap_search($ldap, $userdn, "(objectClass=*)", array("objectClass", $answer_attribute) ); 
+
     $errno = ldap_errno($ldap);
     if ( $errno ) {
         $result = "ldaperror";
@@ -136,14 +136,16 @@ if ( $result === "" ) {
     # Get objectClass values from user entry
     $entry = ldap_first_entry($ldap, $search);
     $ocValues = ldap_get_values($ldap, $entry, "objectClass");
+
     # Remove 'count' key
     unset($ocValues["count"]);
 
     $aValues = ldap_get_values($ldap, $entry, $answer_attribute );
     # Remove 'count' key
     unset($aValues["count"]);
-    
+
     if (! in_array( $answer_objectClass, $ocValues ) ) {
+
         # Answer objectClass is not present, add it
         array_push($ocValues, $answer_objectClass );
         $ocValues = array_values( $ocValues );
@@ -168,6 +170,7 @@ if ( $result === "" ) {
     }
     $userdata[$answer_attribute] = $answers;
     $replace = ldap_mod_replace($ldap, $userdn , $userdata);
+
     $errno = ldap_errno($ldap);
     if ( $errno ) {
         $result = "answermoderror";
@@ -175,6 +178,7 @@ if ( $result === "" ) {
     } else {
         $result = "answerchanged";
     }
+
 }}
 
 #==============================================================================


### PR DESCRIPTION
This updated setquestions.ph makes a few changes. It still does not require that the question attribute be multivalued, but if it is, now supports adding > 1.

1. The search for object class now pulls back the question attribute.
2. If the attribute is present in the search results...
  for each attribute do:
      decrypt question/value (if need be)
      compare the question itself to the question the user want to change.
      if there is a match, perform a ldap_mod_del on the existing attribute.
3. Add the new question/answer.
