### PR TITLE
Configure several LDAP servers and select one depending on context

### DIFF
--- a/conf/config.inc.php
+++ b/conf/config.inc.php
@@ -315,7 +315,7 @@ $default_action = "change";
 #$obscure_failure_messages = array("mailnomatch");
 
 # The name of an HTTP Header that may hold a reference to an extra config file to include.
-$header_name_extra_config="SSP-Extra-Config";
+#$header_name_extra_config="SSP-Extra-Config";
 
 # Allow to override current settings with local configuration
 if (file_exists (__DIR__ . '/config.inc.local.php')) {
@@ -323,10 +323,12 @@ if (file_exists (__DIR__ . '/config.inc.local.php')) {
 }
 
 # Allow to override current settings with an extra configuration file, whose reference is passed in HTTP_HEADER $header_name_extra_config
-$extraConfigKey = "HTTP_".strtoupper(str_replace('-','_',$header_name_extra_config));
-if (array_key_exists($extraConfigKey, $_SERVER)) {
-    $extraConfig = preg_replace("/[^a-zA-Z0-9-_]+/", "", filter_var($_SERVER[$extraConfigKey], FILTER_SANITIZE_STRING, FILTER_FLAG_STRIP_HIGH));
-    if (strlen($extraConfig) > 0 && file_exists (__DIR__ . "/config.inc.".$extraConfig.".php")) {
-        require  __DIR__ . "/config.inc.".$extraConfig.".php";
+if (isset($header_name_extra_config)) {
+    $extraConfigKey = "HTTP_".strtoupper(str_replace('-','_',$header_name_extra_config));
+    if (array_key_exists($extraConfigKey, $_SERVER)) {
+        $extraConfig = preg_replace("/[^a-zA-Z0-9-_]+/", "", filter_var($_SERVER[$extraConfigKey], FILTER_SANITIZE_STRING, FILTER_FLAG_STRIP_HIGH));
+        if (strlen($extraConfig) > 0 && file_exists (__DIR__ . "/config.inc.".$extraConfig.".php")) {
+            require  __DIR__ . "/config.inc.".$extraConfig.".php";
+        }
     }
 }

--- a/conf/config.inc.php
+++ b/conf/config.inc.php
@@ -314,7 +314,19 @@ $default_action = "change";
 # These messages will be replaced by badcredentials error
 #$obscure_failure_messages = array("mailnomatch");
 
+# The name of an HTTP Header that may hold a reference to an extra config file to include.
+$header_name_extra_config="SSP-Extra-Config";
+
 # Allow to override current settings with local configuration
 if (file_exists (__DIR__ . '/config.inc.local.php')) {
     require __DIR__ . '/config.inc.local.php';
+}
+
+# Allow to override current settings with an extra configuration file, whose reference is passed in HTTP_HEADER $header_name_extra_config
+$extraConfigKey = "HTTP_".strtoupper(str_replace('-','_',$header_name_extra_config));
+if (array_key_exists($extraConfigKey, $_SERVER)) {
+    $extraConfig = preg_replace("/[^a-zA-Z0-9-_]+/", "", filter_var($_SERVER[$extraConfigKey], FILTER_SANITIZE_STRING, FILTER_FLAG_STRIP_HIGH));
+    if (strlen($extraConfig) > 0 && file_exists (__DIR__ . "/config.inc.".$extraConfig.".php")) {
+        require  __DIR__ . "/config.inc.".$extraConfig.".php";
+    }
 }


### PR DESCRIPTION
We are setting up a federalized identity management system where users will change their password in their local LDAP server using a federalized SSP. Currently, the only solution would be to install as many SSP instances as we have local LDAP server to change password in, and dispatch users to the right SSP instance when he request a password change.

For many reasons, we would rather have one SSP instance to deal with, so we are proposing a new feature in SSP configuration management:

- Possibility to dynamically override global and local settings with an extra configuration file, whose reference key is passed in an HTTP_HEADER. Config files would be:
   - config.inc.php
   - config.inc.local.php (if exists)
   - config.inc.%extra-config%.php (if exists)

- HTTP Header name is `SSP-Extra-Config` by default, but can be overridden in config.inc.local.php.

For example, if an incoming request has the HTTP header `SSP-Extra-Config` with the value "mypartner", SSP will load the extra configuration file config.inc.mypartner.php.