### PR TITLE
support for sambaKickofftime, issue 334

### DIFF
--- a/conf/config.inc.php
+++ b/conf/config.inc.php
@@ -61,6 +61,7 @@ $samba_mode = false;
 # Set password min/max age in Samba attributes
 #$samba_options['min_age'] = 5;
 #$samba_options['max_age'] = 45;
+#$samba_options['expire_days'] = 90;
 
 # Shadow options - require shadowAccount objectClass
 # Update shadowLastChange

--- a/lib/functions.inc.php
+++ b/lib/functions.inc.php
@@ -298,6 +298,9 @@ function change_password( $ldap, $dn, $password, $ad_mode, $ad_options, $samba_m
         if ( isset($samba_options['max_age']) && $samba_options['max_age'] > 0 ) {
              $userdata["sambaPwdMustChange"] = $time + ( $samba_options['max_age'] * 86400 );
         }
+        if ( isset($samba_options['expire_days']) && $samba_options['expire_days'] > 0 ) {
+             $userdata["sambaKickoffTime"] = $time + ( $samba_options['expire_days'] * 86400 );
+        }
     }
 
     # Get hash type if hash is set to auto


### PR DESCRIPTION
This patch fixes issue 334.

When Samba is updated, `sambaKickoffTime` should be updated too, so any login after a certain configured period is prohibited.