### PR TITLE
Hide token URLs unless debug mode is on

### DIFF
--- a/pages/sendsms.php
+++ b/pages/sendsms.php
@@ -302,9 +302,9 @@ if ( $result === "redirect" ) {
     $reset_url .= "?action=resetbytoken&source=sms&token=".urlencode($token);
 
     if ( !empty($reset_request_log) ) {
-        error_log("Send reset URL $reset_url \n\n", 3, $reset_request_log);
+        error_log("Send reset URL " . ( $debug ? "$reset_url" : "HIDDEN") . "\n\n", 3, $reset_request_log);
     } else {
-        error_log("Send reset URL $reset_url");
+        error_log("Send reset URL " . ( $debug ? "$reset_url" : "HIDDEN") );
     }
 
     # Redirect

--- a/pages/sendtoken.php
+++ b/pages/sendtoken.php
@@ -190,9 +190,9 @@ if ( $result === "" ) {
     $reset_url .= "?action=resetbytoken&token=".urlencode($token);
 
     if ( !empty($reset_request_log) ) {
-        error_log("Send reset URL $reset_url \n\n", 3, $reset_request_log);
+        error_log("Send reset URL " . ( $debug ? "$reset_url" : "HIDDEN") . "\n\n", 3, $reset_request_log);
     } else {
-        error_log("Send reset URL $reset_url");
+        error_log("Send reset URL " . ( $debug ? "$reset_url" : "HIDDEN"));
     }
 
     $data = array( "login" => $login, "mail" => $mail, "url" => $reset_url ) ;


### PR DESCRIPTION
 * Tested for mail page, not on SMS one. 
 * Having full token URL into log could be a security lack. Disable full URL logging unless debug mode is enabled. 