### PR TITLE
Set SMTPOptions from local configuration

### DIFF
--- a/conf/config.inc.php
+++ b/conf/config.inc.php
@@ -210,6 +210,7 @@ $mail_smtp_timeout = 30;
 $mail_smtp_keepalive = false;
 $mail_smtp_secure = 'tls';
 $mail_smtp_autotls = true;
+$mail_smtp_options = array();
 $mail_contenttype = 'text/plain';
 $mail_wordwrap = 0;
 $mail_charset = 'utf-8';

--- a/index.php
+++ b/index.php
@@ -167,6 +167,7 @@ $mailer->SMTPAuth      = $mail_smtp_auth;
 $mailer->Username      = $mail_smtp_user;
 $mailer->Password      = $mail_smtp_pass;
 $mailer->SMTPKeepAlive = $mail_smtp_keepalive;
+$mailer->SMTPOptions   = $mail_smtp_options;
 $mailer->Timeout       = $mail_smtp_timeout;
 $mailer->LE            = $mail_newline;
 


### PR DESCRIPTION
Hello,
In my installation I had to work on the $mailer->SMTPOptions manually as they are not exposed in the configuration file.
This PR exposes the variable in the config file.
See [issue](https://github.com/ltb-project/self-service-password/issues/382).

Thanks!