### PR TITLE
Move inline javascript to its own file fixes (#404)

### DIFF
--- a/index.php
+++ b/index.php
@@ -236,16 +236,7 @@ $mailer->LE            = $mail_newline;
 
 <script src="js/jquery-3.3.1.min.js"></script>
 <script src="js/bootstrap.min.js"></script>
-<script>
-    $(document).ready(function(){
-        // Menu links popovers
-        $('[data-toggle="menu-popover"]').popover({
-            trigger: 'hover',
-            placement: 'bottom',
-            container: 'body' // Allows the popover to be larger than the menu button
-        });
-    });
-</script>
+<script src="js/self-service-password.js"></script>
 </body>
 </html>
 <?php

--- a/js/self-service-password.js
+++ b/js/self-service-password.js
@@ -1,0 +1,8 @@
+$(document).ready(function(){
+    // Menu links popovers
+    $('[data-toggle="menu-popover"]').popover({
+        trigger: 'hover',
+        placement: 'bottom',
+        container: 'body' // Allows the popover to be larger than the menu button
+    });
+});


### PR DESCRIPTION
Move javascript to its own file to allow the use of HTTP Content-Security-Policy script-src

ref https://github.com/ltb-project/self-service-password/issues/404