### PR TITLE
Update config_ldap.rst

### DIFF
--- a/docs/config_ldap.rst
+++ b/docs/config_ldap.rst
@@ -59,19 +59,20 @@ LDAP server, you can try to set this option:
 Credentials
 -----------
 
-Configure DN and password in ``$ldap_bindn`` and ``$ldap_bindpw``:
+Configure DN and password in ``$ldap_bindn`` and ``$ldap_bindpw`` for example a user named SSP:
 
 .. code:: php
 
-   $ldap_binddn = "cn=manager,dc=example,dc=com";
+   $ldap_binddn = "cn=SSP,dc=example,dc=com";
    $ldap_bindpw = "secret";
 
 .. tip:: You can leave these parameters empty to bind anonymously. In
   this case, the password modification must be done with user's
   credentials.
 
-To use user's credentials when writing in LDAP directory, replace
-``manager`` with ``user`` in ``$who_change_password``:
+If you want an SSP account to do this on behalf of the user set the value of ``$who_change_password`` to ``manager``. 
+
+To instead use user's credentials when writing in LDAP directory, replace ``manager`` with ``user`` in ``$who_change_password``:
 
 .. code:: php
 


### PR DESCRIPTION
Previously  in the bind string cn=manager was used, this let to confusion here, as we used the cn value also in $who_change_password.
Now i made it more clear that this attribute is more of a boolean kind it can have two values only.

BTW... please update the website (https://ltb-project.org/documentation/self-service-password) as well to point to this manual,  only after raising this issue i was pointed to this wiki. currently this gip repository forwards to the website for the manual