### PR TITLE
fix(branding): logo in menubar

### DIFF
--- a/htdocs/index.php
+++ b/htdocs/index.php
@@ -169,7 +169,6 @@ $smarty->assign('background_image',$background_image);
 $smarty->assign('custom_css',$custom_css);
 $smarty->assign('version',$version);
 $smarty->assign('display_footer',$display_footer);
-$smarty->assign('logo', $logo);
 $smarty->assign('show_menu', $show_menu);
 $smarty->assign('show_help', $show_help);
 $smarty->assign('use_questions', $use_questions);

--- a/templates/menu.tpl
+++ b/templates/menu.tpl
@@ -9,7 +9,9 @@
                 <span class="icon-bar"></span>
               </button>
               <a class="navbar-brand" href="index.php{if $default_action != 'change'}?action=change{/if}">
-                <i class="fa fa-fw fa-home"></i>{$msg_title}</a>
+                <img src="{$logo}" alt="{$msg_title}" class="menu-logo img-responsive" />
+                {$msg_title}
+              </a>
             </div>
             <div class="navbar-collapse collapse">
               <ul class="nav navbar-nav">


### PR DESCRIPTION
looking at whitepages (https://github.com/ltb-project/white-pages/blob/master/templates/menu.tpl#L13) and servicedesk (https://github.com/ltb-project/service-desk/blob/master/templates/menu.tpl#L13), there should be a logo in the menu bar.

also: removes a duplicate smarty assign (already done a few lines above the one I'm removing: https://github.com/ltb-project/self-service-password/blob/579e16c9f82cd80aeb19d229ec697b03ba587648/htdocs/index.php#L167)
