### PR TITLE
Link to github page added to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,7 @@ Documentation is available on http://ltb-project.org/wiki/documentation/self-ser
 ## Download
 
 Tarballs and packages for Debian and Red Hat are available on http://ltb-project.org/wiki/download#self_service_password
+
+## Source code
+
+Source codes are available on https://github.com/ltb-project/self-service-password


### PR DESCRIPTION
There is no any link to github project page in README.md
It would be nice to have one