### PR TITLE
Remove extra semicolon from setquestions template

### DIFF
--- a/templates/setquestions.tpl
+++ b/templates/setquestions.tpl
@@ -1,7 +1,7 @@
 {if $show_help}
     <div class="help alert alert-warning">
     <p><i class="fa fa-fw fa-info-circle"></i> {$msg_setquestionshelp|unescape: "html" nofilter}</p>
-    </div>;
+    </div>
 {/if}
 <div class="alert alert-info">
 <form action="#" method="post" class="form-horizontal">


### PR DESCRIPTION
This fixes an erroneous extra semicolon in the setquestions template (`index.php?action=setquestions`):

![Screenshot_20210423_000850](https://user-images.githubusercontent.com/25122064/115791364-9693fe00-a3c8-11eb-8074-9ca8e5a6c38b.png)
