### PR TITLE
Remove alt text so empty logo doesn't show 'msg_title' twice

### DIFF
--- a/templates/menu.tpl
+++ b/templates/menu.tpl
@@ -10,7 +10,7 @@
               </button>
               <a class="navbar-brand" href="index.php{if $default_action != 'change'}?action=change{/if}">
                 {if $logo}
-                <img src="{$logo}" alt="{$msg_title}" class="menu-logo img-responsive" />
+                <img src="{$logo}" alt="Logo" class="menu-logo img-responsive" />
                 {/if}
                 {$msg_title}
               </a>

--- a/templates/menu.tpl
+++ b/templates/menu.tpl
@@ -9,7 +9,9 @@
                 <span class="icon-bar"></span>
               </button>
               <a class="navbar-brand" href="index.php{if $default_action != 'change'}?action=change{/if}">
+                {if $logo}
                 <img src="{$logo}" alt="{$msg_title}" class="menu-logo img-responsive" />
+                {/if}
                 {$msg_title}
               </a>
             </div>


### PR DESCRIPTION
Here's another tiny fix: This removes the `alt` attribute from the logo's `img` tag. If the logo is empty `msg_title` will show twice otherwise, e.g.

![Screenshot_20210423_114704](https://user-images.githubusercontent.com/25122064/115853672-b7407000-a429-11eb-9f77-b8613916b423.png)
