### PR TITLE
core(update): apache 2.4.46

### DIFF
--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -11,6 +11,7 @@ RUN buildDeps=" \
         libonig-dev \
     " \
     runtimeDeps=" \
+	apache2/buster-backports \
         curl \
         libicu-dev \
         libldap2-dev \
@@ -23,6 +24,7 @@ RUN buildDeps=" \
 	locales-all \
 	sendmail \
     " \
+    && echo deb http://deb.debian.org/debian buster-backports main >>/etc/apt/sources.list \
     && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y $buildDeps $runtimeDeps \
     && docker-php-ext-install bcmath bz2 iconv intl mbstring opcache curl \
     && docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp \


### PR DESCRIPTION
As pointed out by @fuyangqing , in https://github.com/ltb-project/self-service-password/issues/532
The Apache version shipping today with Debian buster has known vulnerabilities (2.4.38).
We could update it to 2.4.46, pulling Apache from the buster-backports repository instead.