### PR TITLE
fix(notify): don't send notification if modification failed

### DIFF
--- a/htdocs/changesshkey.php
+++ b/htdocs/changesshkey.php
@@ -154,9 +154,11 @@ if ( $result === "" ) {
 #==============================================================================
 # Notify password change
 #==============================================================================
-if ($mail and $notify_on_sshkey_change) {
-    $data = array( "login" => $login, "mail" => $mail, "sshkey" => $sshkey);
-    if ( !send_mail($mailer, $mail, $mail_from, $mail_from_name, $messages["changesshkeysubject"], $messages["changesshkeymessage"].$mail_signature, $data) ) {
-        error_log("Error while sending change email to $mail (user $login)");
+if ($result === "sshkeychanged") {
+    if ($mail and $notify_on_sshkey_change) {
+	$data = array( "login" => $login, "mail" => $mail, "sshkey" => $sshkey);
+	if ( !send_mail($mailer, $mail, $mail_from, $mail_from_name, $messages["changesshkeysubject"], $messages["changesshkeymessage"].$mail_signature, $data) ) {
+	    error_log("Error while sending change email to $mail (user $login)");
+	}
     }
 }


### PR DESCRIPTION
changing an ssh key, mail notifications would be issued, even when we failed to update keys in LDAP