### PR TITLE
docs(ratelimit): typo

### DIFF
--- a/docs/config_general.rst
+++ b/docs/config_general.rst
@@ -211,7 +211,7 @@ per login and per hour, and same for ip address:
 
 .. code:: php
 
-   $enable_ratelimit = true;
+   $use_ratelimit = true;
 
 Other possible options for rate limiting:
 


### PR DESCRIPTION
Wrong option documented enabling ratelimit checks.
Reported here: ltb-project/self-service-password#544