### PR TITLE
fix(docs): ratelimit check interval should be 1h, not 1min

### DIFF
--- a/conf/config.inc.php
+++ b/conf/config.inc.php
@@ -99,7 +99,7 @@ $max_attempts_per_user = 2;
 # block attempts for same IP ?
 $max_attempts_per_ip = 2;
 # how many time to refuse subsequent requests ?
-$max_attempts_block_seconds = "60";
+$max_attempts_block_seconds = "3600";
 # Header to use for client IP (HTTP_X_FORWARDED_FOR ?)
 $client_ip_header = 'REMOTE_ADDR';
 

--- a/conf/config.inc.php
+++ b/conf/config.inc.php
@@ -99,7 +99,7 @@ $max_attempts_per_user = 2;
 # block attempts for same IP ?
 $max_attempts_per_ip = 2;
 # how many time to refuse subsequent requests ?
-$max_attempts_block_seconds = "3600";
+$max_attempts_block_seconds = "60";
 # Header to use for client IP (HTTP_X_FORWARDED_FOR ?)
 $client_ip_header = 'REMOTE_ADDR';
 

--- a/docs/config_general.rst
+++ b/docs/config_general.rst
@@ -220,7 +220,7 @@ Other possible options for rate limiting:
    $ratelimit_dbdir = '/tmp';
    $max_attempts_per_user = 2;
    $max_attempts_per_ip = 2;
-   $max_attempts_block_seconds = "60";
+   $max_attempts_block_seconds = "3600";
    $client_ip_header = 'REMOTE_ADDR';
 
 Default action

--- a/docs/config_general.rst
+++ b/docs/config_general.rst
@@ -207,7 +207,7 @@ displayed and replaced by a generic "bad credentials" error:
 
 You may want to limit number of tries per user/ip in a short time 
 (especially with sms option). If you enable this defaults are 2 tries
-per login and per hour, and same for ip address:
+per login and per minute, and same for ip address:
 
 .. code:: php
 
@@ -220,7 +220,7 @@ Other possible options for rate limiting:
    $ratelimit_dbdir = '/tmp';
    $max_attempts_per_user = 2;
    $max_attempts_per_ip = 2;
-   $max_attempts_block_seconds = "3600";
+   $max_attempts_block_seconds = "60";
    $client_ip_header = 'REMOTE_ADDR';
 
 Default action


### PR DESCRIPTION
Doc mentions ratelimit would last for 1h.
Then quotes the defaults from `config.inc.php`: `60s`.

Set it to 1h everywhere.