### PR TITLE
fix(api): phpmailer needs to be included (#573)

### DIFF
--- a/rest/v1/include.php
+++ b/rest/v1/include.php
@@ -10,9 +10,7 @@ require_once("../../conf/config.inc.php");
 #==============================================================================
 require_once("../../lib/vendor/defuse-crypto.phar");
 require_once("../../lib/functions.inc.php");
-if ($use_pwnedpasswords) {
-    require_once("../../lib/vendor/autoload.php");
-}
+require_once("../../lib/vendor/autoload.php");
 
 #==============================================================================
 # VARIABLES


### PR DESCRIPTION
as reported by @ilanni2460 
When use_pwndpasswords is false, phpmailer init would result in error 500