### PR TITLE
add required objectClass for sshkey attribute, if needed

### DIFF
--- a/conf/config.inc.php
+++ b/conf/config.inc.php
@@ -174,6 +174,9 @@ $change_sshkey = false;
 # What attribute should be changed by the changesshkey action?
 $change_sshkey_attribute = "sshPublicKey";
 
+# which objectClass is required for that attribute
+$required_sshkey_objectclass = "";
+
 # Ensure the SSH Key submitted uses a type we trust
 $ssh_valid_key_types = array('ssh-rsa', 'ssh-dss', 'ecdsa-sha2-nistp256', 'ecdsa-sha2-nistp384', 'ecdsa-sha2-nistp521', 'ssh-ed25519');
 

--- a/htdocs/changesshkey.php
+++ b/htdocs/changesshkey.php
@@ -150,6 +150,12 @@ if ( $result === "" ) {
     }
 }
 
+#==============================================================================
+# Check for sshPublicKey objectClass
+#==============================================================================
+if ( $result === "") {
+    $result = check_sshkey_objectclass($ldap, $userdn, $required_sshkey_objectclass );
+}
 
 #==============================================================================
 # Change sshPublicKey

--- a/lang/en.inc.php
+++ b/lang/en.inc.php
@@ -37,6 +37,7 @@ $messages['nomatch'] = "Passwords mismatch";
 $messages['badcredentials'] = "Login or password incorrect";
 $messages['passworderror'] = "Password was refused by the LDAP directory";
 $messages['sshkeyerror'] = "SSH Key was refused by the LDAP directory";
+$messages['sshkeyobjectclasserror'] = "Required objectClass for SSH Key was refused by the LDAP directory";
 $messages['title'] = "Self service password";
 $messages['login'] = "Login";
 $messages['oldpassword'] = "Old password";


### PR DESCRIPTION
Added a configuration parameter to be able to specify a required LDAP ObjectClass for the SSHKEY attribute. If the parameter is set, the system checks whether the specified ObjectClass is entered before changing the SSHKEY attribute. If not, it is added to the user. Issue #608 