### PR TITLE
Add some cosmetic css properties to sshkey textarea

### DIFF
--- a/htdocs/css/self-service-password.css
+++ b/htdocs/css/self-service-password.css
@@ -56,6 +56,13 @@ div#footer {
   width:100%;
 }
 
+textarea#sshkey {
+  font-family: monospace;
+  word-break: break-all;
+  resize: vertical;
+  min-height: 10em;
+}
+
 @media print {
 
   html, body {


### PR DESCRIPTION
This adds some cosmetic properties to the `sshkey` textarea. In particular:

- `resize: vertical;`
  This prevents a user from (accidentally) horizontally resizing the textarea which looks rather out of place:

![Screenshot_20220307_120353](https://user-images.githubusercontent.com/25122064/157020029-91b0678c-f85d-4895-bc16-ad9508cbc75f.png)

- `font-family: monospace;`
  A monospaced font seems more fitting for an ssh key

- `word-break: break-all;`
 This prevents a line break on a forward slash:

![Screenshot_20220307_121829](https://user-images.githubusercontent.com/25122064/157021668-bfa48bea-bbf2-461b-b742-ed94c0bd52d4.png)

vs.

![Screenshot_20220307_121819](https://user-images.githubusercontent.com/25122064/157021678-0c41a085-ea1a-4ada-a198-7c23bb11bb76.png)

- `min-height: 10em;`
  This ensures the textarea is tall enough so a 2048 bit RSA public key (which is hopefully the smallest sized used these days) can be pasted without a scroll bar appearing and automatically scrolling past the beginning.  
  Otherwise one might wonder if the correct thing was pasted since it's not immediately obvious:
  
![Screenshot_20220307_122254](https://user-images.githubusercontent.com/25122064/157022166-d394974e-2f68-4ae5-961f-0f272064f796.png)

Maybe it's even a good idea to make this tall enough for a 3072 bit RSA key since that's the default for ssh-keygen or 4096 bits.