### PR TITLE
AD doesnt accept TLS

### DIFF
--- a/docs/config_ldap.rst
+++ b/docs/config_ldap.rst
@@ -164,14 +164,13 @@ field:
 .. code:: php
 
    $ad_mode = true;
-   $ldap_starttls = false;
 
 You must also use SSL on LDAP connection because AD refuses to change a
 password on a clear connection. See this
 `documentation <https://ltb-project.org/documentation/active_directory_certificates.html>`__
 to manage Active Directory certificates.
 
-Tls must be in for AD:
+Tls must be false for AD:
 
 .. code:: php
 

--- a/docs/config_ldap.rst
+++ b/docs/config_ldap.rst
@@ -164,11 +164,18 @@ field:
 .. code:: php
 
    $ad_mode = true;
+   $ldap_starttls = false;
 
 You must also use SSL on LDAP connection because AD refuses to change a
 password on a clear connection. See this
 `documentation <https://ltb-project.org/documentation/active_directory_certificates.html>`__
 to manage Active Directory certificates.
+
+Tls must be in for AD:
+
+.. code:: php
+
+   $ldap_starttls = false;
 
 Adapt the search filter too:
 


### PR DESCRIPTION
Just adding some lines to config_ldap.rst
Specifying the TLS false for AD
It was a bit difficult for me to get it to work with AD because I didn't know it worked without TLS