### PR TITLE
feat(sms): Allow more than one mobile attribute #658

### DIFF
--- a/conf/config.inc.php
+++ b/conf/config.inc.php
@@ -277,10 +277,10 @@ $use_sms = true;
 $sms_method = "mail";
 $sms_api_lib = "lib/smsapi.inc.php";
 # GSM number attribute
-$sms_attribute = "mobile";
+$sms_attributes = array( "mobile", "pager", "ipPhone", "homephone" );
 # Partially hide number
 $sms_partially_hide_number = true;
-# Send SMS mail to address
+# Send SMS mail to address. {sms_attribute} will be replaced by real sms number
 $smsmailto = "{sms_attribute}@service.provider.com";
 # Subject when sending email to SMTP to SMS provider
 $smsmail_subject = "Provider code";

--- a/docs/config_sms.rst
+++ b/docs/config_sms.rst
@@ -60,11 +60,17 @@ trough mail configuration (see :ref:`config_mail`).
 
 You can adjust some settings here, depending on provider guidelines:
 
+To set SMS mail to address.
+Within smssmailto {sms_attribute} will be replaced by sms number.
+
 .. code:: php
 
-   # Send SMS mail to address
    $smsmailto = "{sms_attribute}@service.provider.com";
-   # Subject when sending email to SMTP to SMS provider
+
+Subject when sending email to SMTP to SMS provider
+
+.. code:: php
+
    $smsmail_subject = "Provider code";
 
 API
@@ -102,11 +108,12 @@ See also :ref:`sms_api`.
 Mobile attribute
 ----------------
 
-Set here which LDAP attribute hold the user mobile phone:
+Set here which LDAP attributes hold the user mobile phone, first found
+will be used :
 
 .. code:: php
 
-   $sms_attribute = "mobile";
+   $sms_attributes = array( "mobile", "pager", "ipPhone", "homephone" );
 
 You can also partially hide the value when it is displayed on the
 confirmation page:

--- a/htdocs/sendsms.php
+++ b/htdocs/sendsms.php
@@ -21,6 +21,8 @@
 
 # This page is called to send random generated password to user by SMS
 
+require_once("../lib/LtbAttributeValue_class.php");
+
 #==============================================================================
 # POST parameters
 #==============================================================================
@@ -166,19 +168,19 @@ if ( $result === "" ) {
                     $result = "badcredentials";
                     error_log("LDAP - User $login not found");
                 } else {
-                    # Get sms values
-                    $smsValues = ldap_get_values($ldap, $entry, $sms_attribute);
+                    # Get first sms number for configured ldap attributes in sms_attributes.
+                    $smsValue = LtbAttributeValue::ldap_get_first_available_value($ldap, $entry, $sms_attributes);
                 }
                 # Check sms number
-                if ( $smsValues["count"] > 0 ) {
-                    $sms = $smsValues[0];
+                if ( $smsValue ) {
+                    $sms = $smsValue->value;
                     if ( $sms_sanitize_number ) {
                         $sms = preg_replace('/[^0-9]/', '', $sms);
                     }
                     if ( $sms_truncate_number ) {
                         $sms = substr($sms, -$sms_truncate_number_length);
                     }
-                   $smsdisplay = $sms;
+                    $smsdisplay = $sms;
                     if ( $sms_partially_hide_number ) {
                         $smsdisplay = substr_replace($sms, '****', 4 , 4);
                     }

--- a/lib/LtbAttributeValue_class.php
+++ b/lib/LtbAttributeValue_class.php
@@ -1,0 +1,51 @@
+<?php
+#==============================================================================
+# LTB Self Service Password
+#
+# Copyright (C) 2009 Clement OUDOT
+# Copyright (C) 2009 LTB-project.org
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# GPL License: http://www.gnu.org/licenses/gpl.txt
+#
+#==============================================================================
+
+class LtbAttributeValue {
+    public $attribute;
+    public $value;
+
+    public function __construct($attribute, $value) {
+        $this->attribute = $attribue;
+        $this->value = $value;
+    }
+
+    /** function LtbAttributeValue.ldap_get_first_available_value($ldap, $entry, $attributes)
+     * Get from ldap entry first value of first existing attribute  within $attributes in order
+     * @param $ldap ldap connection object
+     * @param $entry ldap entry to parse
+     * @param $attributes array of attributes names
+     * @return object LtbAttributeValue of found attribute and value, or false if not found
+     */
+    public static function ldap_get_first_available_value($ldap, $entry, $attributes)
+    {
+        # loop on attributes, stop on first found
+        for ($i = 0; $i < sizeof($attributes); $i++) {
+            $attribute = $attributes[$i];
+            $values = ldap_get_values($ldap, $entry, $attribute);
+            if ( $values && ( $values['count'] > 0 ) ) {
+                return new LtbAttributeValue($attribute,$values[0]);
+            }
+        }
+        return false;
+    }
+
+}


### PR DESCRIPTION
- replace $sms_attribute string by $sms_attributes array of string
  - update default configuration with attribute list
    mobile pager ipPhone homephone
  - update documentation
- provide a new function ltb_filter_attributes($ldap, $entry, $attributes)
  - ltd_ prefix to clarify what componenr provides this feature
    ie this is not in php_ldap extension
  - for future use to factorize this for existing mail feature
    - new class LtbAttributeValue
      keep track of attribute name and value binding
- update existing documentation for smssmailto
  - clarify {sms_attribute} usage
    this is not attribute name of configuration but actual gathered sms number