### PR TITLE
captcha use dedicated session cookie fix #602

### DIFF
--- a/htdocs/captcha.php
+++ b/htdocs/captcha.php
@@ -21,10 +21,19 @@
 
 require_once("../lib/vendor/autoload.php");
 use Gregwar\Captcha\CaptchaBuilder;
+
+# cookie for captcha session
+ini_set("session.use_cookies",1);
+ini_set("session.use_only_cookies",1);
+session_name("captcha");
 session_start();
 
 $captcha = new CaptchaBuilder;
 $_SESSION['phrase'] = $captcha->getPhrase();
+
+# session is stored and closed now, used only for captcha
+session_write_close();
+
 header('Content-Type: image/jpeg');
 $captcha
     ->build()

--- a/htdocs/change.php
+++ b/htdocs/change.php
@@ -32,17 +32,12 @@ $login = $presetLogin;
 $confirmpassword = "";
 $newpassword = "";
 $oldpassword = "";
-$captchaphrase = "";
 $ldap = "";
 $userdn = "";
 if (!isset($pwd_forbidden_chars)) { $pwd_forbidden_chars=""; }
 $mail = "";
 $extended_error_msg = "";
 
-if ($use_captcha) {
-    if (isset($_POST["captchaphrase"]) and $_POST["captchaphrase"]) { $captchaphrase = strval($_POST["captchaphrase"]); }
-    else { $result = "captcharequired"; }
-}
 if (isset($_POST["confirmpassword"]) and $_POST["confirmpassword"]) { $confirmpassword = strval($_POST["confirmpassword"]); }
 else { $result = "confirmpasswordrequired"; }
 if (isset($_POST["newpassword"]) and $_POST["newpassword"]) { $newpassword = strval($_POST["newpassword"]); }
@@ -66,13 +61,7 @@ if ( $newpassword != $confirmpassword ) { $result="nomatch"; }
 #==============================================================================
 # Check captcha
 #==============================================================================
-if ( $result === "" && $use_captcha ) {
-    session_start();
-    if ( !check_captcha($_SESSION['phrase'], $captchaphrase) ) {
-        $result = "badcaptcha";
-    }
-    unset($_SESSION['phrase']);
-}
+if ( ( $result === "" ) and $use_captcha) { $result = global_captcha_check();}
 
 #==============================================================================
 # Check old password

--- a/htdocs/changesshkey.php
+++ b/htdocs/changesshkey.php
@@ -34,12 +34,7 @@ $sshkey = "";
 $ldap = "";
 $userdn = "";
 $mail = "";
-$captchaphrase = "";
 
-if ($use_captcha) {
-    if (isset($_POST["captchaphrase"]) and $_POST["captchaphrase"]) { $captchaphrase = strval($_POST["captchaphrase"]); }
-    else { $result = "captcharequired"; }
-}
 if (isset($_POST["password"]) and $_POST["password"]) { $password = strval($_POST["password"]); }
 else { $result = "passwordrequired"; }
 if (isset($_POST["sshkey"]) and $_POST["sshkey"]) {
@@ -60,13 +55,7 @@ if ( $result === "" ) {
 #==============================================================================
 # Check captcha
 #==============================================================================
-if ( $result === "" && $use_captcha ) {
-    session_start();
-    if ( !check_captcha($_SESSION['phrase'], $captchaphrase) ) {
-        $result = "badcaptcha";
-    }
-    unset($_SESSION['phrase']);
-}
+if ( ( $result === "" ) and $use_captcha) { $result = global_captcha_check();}
 
 #==============================================================================
 # Check password

--- a/htdocs/resetbyquestions.php
+++ b/htdocs/resetbyquestions.php
@@ -33,7 +33,6 @@ $question = [];
 $answer = [];
 $newpassword = "";
 $confirmpassword = "";
-$captchaphrase = "";
 $ldap = "";
 $userdn = "";
 if (!isset($pwd_forbidden_chars)) { $pwd_forbidden_chars=""; }
@@ -41,12 +40,9 @@ $mail = "";
 $extended_error_msg = "";
 $questions_count = $multiple_answers ? $questions_count : 1;
 
-if ($use_captcha) {
-    if (isset($_POST["captchaphrase"]) and $_POST["captchaphrase"]) { $captchaphrase = strval($_POST["captchaphrase"]); }
-    else { $result = "captcharequired"; }
-}
 if (isset($_POST["confirmpassword"]) and $_POST["confirmpassword"]) { $confirmpassword = strval($_POST["confirmpassword"]); }
 else { $result = "confirmpasswordrequired"; }
+
 if (isset($_POST["newpassword"]) and $_POST["newpassword"]) { $newpassword = strval($_POST["newpassword"]); }
 else { $result = "newpasswordrequired"; }
 
@@ -63,6 +59,7 @@ if (isset($_POST["answer"]) and $_POST["answer"]) {
 } else {
     $result = "answerrequired";
 }
+
 if (isset($_POST["question"]) and $_POST["question"]) {
     if ($questions_count > 1) {
       $question = $_POST["question"];
@@ -89,13 +86,7 @@ if ( $result === "" ) {
 #==============================================================================
 # Check captcha
 #==============================================================================
-if ( $result === "" && $use_captcha ) {
-    session_start();
-    if ( !check_captcha($_SESSION['phrase'], $captchaphrase) ) {
-        $result = "badcaptcha";
-    }
-    unset($_SESSION['phrase']);
-}
+if ( ( $result === "" ) and $use_captcha) { $result = global_captcha_check();}
 
 # Should we pre-populate the question?
 #   This should ensure that $login is valid and everything else is empty.

--- a/htdocs/resetbytoken.php
+++ b/htdocs/resetbytoken.php
@@ -54,6 +54,8 @@ if ( $result === "" ) {
         $tokenid = $token;
     }
 
+    # select internal session by $tokenid without relying on cookie or url
+    # will gather login,time and smstoken values from session.
     ini_set("session.use_cookies",0);
     ini_set("session.use_only_cookies",1);
 

--- a/htdocs/sendsms.php
+++ b/htdocs/sendsms.php
@@ -37,13 +37,16 @@ $smstoken = "";
 $token = "";
 $sessiontoken = "";
 $attempts = 0;
-$captchaphrase = "";
 
-if ($use_captcha) {
-    if (isset($_POST["captchaphrase"]) and $_POST["captchaphrase"]) { $captchaphrase = strval($_POST["captchaphrase"]); }
-    elseif (!(isset($_REQUEST["smstoken"]) and isset($_REQUEST["token"]))) { $result = "captcharequired"; }
-}
-if (!$crypt_tokens) {
+#==============================================================================
+# Check captcha
+#==============================================================================
+if ($use_captcha) { $result = global_captcha_check();}
+
+if (! ($result === "") ) {
+    # result was already set
+    # done this way to keep indentation
+} elseif (!$crypt_tokens) {
     $result = "crypttokensrequired";
 } elseif (isset($_REQUEST["smstoken"]) and isset($_REQUEST["token"])) {
     $token = strval($_REQUEST["token"]);
@@ -106,17 +109,6 @@ if (!$crypt_tokens) {
 # Check the entered username for characters that our installation doesn't support
 if ( $result === "" ) {
     $result = check_username_validity($login,$login_forbidden_chars);
-}
-
-#==============================================================================
-# Check captcha
-#==============================================================================
-if ( $result === "" && $use_captcha ) {
-    session_start();
-    if ( !check_captcha($_SESSION['phrase'], $captchaphrase) ) {
-        $result = "badcaptcha";
-    }
-    unset($_SESSION['phrase']);
 }
 
 #==============================================================================

--- a/htdocs/sendtoken.php
+++ b/htdocs/sendtoken.php
@@ -32,7 +32,6 @@ $ldap = "";
 $userdn = "";
 $token = "";
 $usermail = "";
-$captchaphrase = "";
 
 if (!$mail_address_use_ldap) {
     if (isset($_POST["mail"]) and $_POST["mail"]) {
@@ -45,14 +44,11 @@ if (!$mail_address_use_ldap) {
         $result = "mailrequired";
     }
 }
-if ($use_captcha) {
-    if (isset($_POST["captchaphrase"]) and $_POST["captchaphrase"]) { $captchaphrase = strval($_POST["captchaphrase"]); }
-     else { $result = "captcharequired"; }
-}
-if (isset($_REQUEST["login"]) and $_REQUEST["login"]) { $login = strval($_REQUEST["login"]); }
- else { $result = "loginrequired"; }
-if (! isset($_POST["mail"]) and ! isset($_REQUEST["login"]))
- { $result = "emptysendtokenform"; }
+
+if (isset($_REQUEST["login"]) and $_REQUEST["login"]) { $login = strval($_REQUEST["login"]);}
+else { $result = "loginrequired";}
+
+if (! isset($_POST["mail"]) and ! isset($_REQUEST["login"])) { $result = "emptysendtokenform"; }
 
 # Check the entered username for characters that our installation doesn't support
 if ( $result === "" ) {
@@ -62,13 +58,7 @@ if ( $result === "" ) {
 #==============================================================================
 # Check captcha
 #==============================================================================
-if ( $result === "" && $use_captcha ) {
-    session_start();
-    if ( !check_captcha($_SESSION['phrase'], $captchaphrase) ) {
-        $result = "badcaptcha";
-    }
-    unset($_SESSION['phrase']);
-}
+if ( ( $result === "" ) and $use_captcha) { $result = global_captcha_check();}
 
 #==============================================================================
 # Check mail

--- a/htdocs/setquestions.php
+++ b/htdocs/setquestions.php
@@ -33,7 +33,6 @@ $answer = [];
 $ldap = "";
 $userdn = "";
 $questions_count = $multiple_answers ? $questions_count : 1;
-$captchaphrase = "";
 
 # Use arrays for question/answer, to accommodate multiple questions on the same page
 if (isset($_POST["answer"]) and $_POST["answer"]) {
@@ -60,10 +59,6 @@ if (isset($_POST["question"]) and $_POST["question"]) {
 } else {
   $result = "questionrequired";
 }
-if ($use_captcha) {
-    if (isset($_POST["captchaphrase"]) and $_POST["captchaphrase"]) { $captchaphrase = strval($_POST["captchaphrase"]); }
-     else { $result = "captcharequired"; }
-}
 if (isset($_POST["password"]) and $_POST["password"]) { $password = strval($_POST["password"]); }
  else { $result = "passwordrequired"; }
 if (isset($_REQUEST["login"]) and $_REQUEST["login"]) { $login = strval($_REQUEST["login"]); }
@@ -79,13 +74,7 @@ if ( $result === "" ) {
 #==============================================================================
 # Check captcha
 #==============================================================================
-if ( $result === "" && $use_captcha ) {
-    session_start();
-    if ( !check_captcha($_SESSION['phrase'], $captchaphrase) ) {
-        $result = "badcaptcha";
-    }
-    unset($_SESSION['phrase']);
-}
+if ( ( $result === "" ) and $use_captcha) { $result = global_captcha_check();}
 
 #==============================================================================
 # Check password

--- a/lib/captcha.inc.php
+++ b/lib/captcha.inc.php
@@ -26,3 +26,27 @@ use Gregwar\Captcha\PhraseBuilder;
 function check_captcha( $captcha_value, $user_value ) {
     return PhraseBuilder::comparePhrases($captcha_value,$user_value);
 }
+
+# see ../htdocs/captcha.php where captcha cookie and $_SESSION['phrase'] are set.
+function global_captcha_check() {
+    $result="";
+    if (isset($_POST["captchaphrase"]) and $_POST["captchaphrase"]) {
+        # captcha cookie for session
+        ini_set("session.use_cookies",1);
+        ini_set("session.use_only_cookies",1);
+        setcookie("captcha", '', time()-1000);
+        session_name("captcha");
+        session_start();
+        $captchaphrase = strval($_POST["captchaphrase"]);
+        if (!isset($_SESSION['phrase']) or !check_captcha($_SESSION['phrase'], $captchaphrase)) {
+            $result = "badcaptcha";
+        }
+        unset($_SESSION['phrase']);
+        # write session to make sure captcha phrase is no more included in session.
+        session_write_close();
+    }
+    else {
+        $result = "captcharequired";
+    }
+    return $result;
+}


### PR DESCRIPTION
- handle whole captcha statefull phrase read within function global_captcha_check
- there is a dedicated cookie named captcha used to find phrase corresponding
  to displayed image from server php session
- make sure to close session that will be recreated for token or smstoken purposes
  since it is not possible to keep multiple sessions open

TODO :
- fail captcha earlier without any additonnal checking.
- use other means to persist data on server side than using session.
- don't use cookie at all