### PR TITLE
Rate limit optional support per ip (ratelimit_filter_by_ip)

### DIFF
--- a/conf/config.inc.php
+++ b/conf/config.inc.php
@@ -107,6 +107,8 @@ $max_attempts_per_ip = 2;
 $max_attempts_block_seconds = "60";
 # Header to use for client IP (HTTP_X_FORWARDED_FOR ?)
 $client_ip_header = 'REMOTE_ADDR';
+# JSON file to filter by IP
+#$ratelimit_filter_by_ip_jsonfile = "/usr/share/self-service-password/conf/rrl_filter_by_ip.json";
 
 # Local password policy
 # This is applied before directory password policy

--- a/docs/config_general.rst
+++ b/docs/config_general.rst
@@ -222,24 +222,6 @@ displayed and replaced by a generic "bad credentials" error:
 
    $obscure_failure_messages = array("mailnomatch");
 
-You may want to limit number of tries per user/ip in a short time 
-(especially with sms option). If you enable this defaults are 2 tries
-per login and per minute, and same for ip address:
-
-.. code:: php
-
-   $use_ratelimit = true;
-
-Other possible options for rate limiting:
-
-.. code:: php
-
-   $ratelimit_dbdir = '/tmp';
-   $max_attempts_per_user = 2;
-   $max_attempts_per_ip = 2;
-   $max_attempts_block_seconds = "60";
-   $client_ip_header = 'REMOTE_ADDR';
-
 Default action
 --------------
 

--- a/docs/config_rate_limit.rst
+++ b/docs/config_rate_limit.rst
@@ -1,9 +1,9 @@
 Rate limit
 ==========
 
-You may want to limit number of tries per user/ip in a short time
-(especially with sms option). If you enable this defaults are 2 tries
-per login and per minute, and same for ip address:
+You may want to limit number of tries per user/IP in a short time
+(especially with sms option). If you enable this, defaults are 2 tries
+per login and per minute, and same for IP address:
 
 .. code:: php
 
@@ -19,30 +19,30 @@ Other possible options for rate limiting:
    $max_attempts_block_seconds = "60";
    $client_ip_header = 'REMOTE_ADDR';
 
-You may want to controls rate_limit by ip.
-To do so you have to specify full local path of file containing json of ip and expected behavior.
-By default $ratelimit_filter_by_ip_jsonfile is empty, no exclusion is applied.
+You may want to control rate_limit by IP.
+To do so you have to specify full local path of file containing json of IP and expected behavior.
+By default ``$ratelimit_filter_by_ip_jsonfile`` is empty, no exclusion is applied.
 
 .. code:: php
 
    $ratelimit_filter_by_ip_jsonfile = '/var/www/conf/rrl_filter_by_ip.json';
 
 
-Example of rrl_filter_by_ip.json file
+Example of ``rrl_filter_by_ip.json`` file :
 
 .. code-block:: json
 
-{
+  {
     "127.0.0.1":{"per_time":"infinite"},
     "172.28.0.1":{"max_per_ip":"infinite","max_per_user":30}
-}
+  }
 
-values are integers, excepting for "infinite" word where check for rate will be disabled.
+Values are integers, excepting for ``infinite`` word where check for rate will be disabled.
 
-if no value is given then default will be used
+If no value is given then default will be used:
 
-max_per_ip missing uses $max_attempts_per_ip
-max_per_user missing uses $max_attempts_per_user
-per_time missing uses $max_attempts_block_seconds
+* ``max_per_ip`` missing uses ``$max_attempts_per_ip``
+* ``max_per_user`` missing uses ``$max_attempts_per_user``
+* ``per_time`` missing uses ``$max_attempts_block_seconds``
 
-when per_time is set to infinite no check will be done when related ip is used.
+When ``per_time`` is set to ``infinite`` no check will be done when related IP is used.

--- a/docs/config_rate_limit.rst
+++ b/docs/config_rate_limit.rst
@@ -1,0 +1,48 @@
+Rate limit
+==========
+
+You may want to limit number of tries per user/ip in a short time
+(especially with sms option). If you enable this defaults are 2 tries
+per login and per minute, and same for ip address:
+
+.. code:: php
+
+   $use_ratelimit = true;
+
+Other possible options for rate limiting:
+
+.. code:: php
+
+   $ratelimit_dbdir = '/tmp';
+   $max_attempts_per_user = 2;
+   $max_attempts_per_ip = 2;
+   $max_attempts_block_seconds = "60";
+   $client_ip_header = 'REMOTE_ADDR';
+
+You may want to controls rate_limit by ip.
+To do so you have to specify full local path of file containing json of ip and expected behavior.
+By default $ratelimit_filter_by_ip_jsonfile is empty, no exclusion is applied.
+
+.. code:: php
+
+   $ratelimit_filter_by_ip_jsonfile = '/var/www/conf/rrl_filter_by_ip.json';
+
+
+Example of rrl_filter_by_ip.json file
+
+.. code-block:: json
+
+{
+    "127.0.0.1":{"per_time":"infinite"},
+    "172.28.0.1":{"max_per_ip":"infinite","max_per_user":30}
+}
+
+values are integers, excepting for "infinite" word where check for rate will be disabled.
+
+if no value is given then default will be used
+
+max_per_ip missing uses $max_attempts_per_ip
+max_per_user missing uses $max_attempts_per_user
+per_time missing uses $max_attempts_block_seconds
+
+when per_time is set to infinite no check will be done when related ip is used.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -19,5 +19,6 @@ LDAP Tool Box Self Service Password documentation
    config_mail.rst
    config_preposthook.rst
    config_sshkey.rst
+   config_rate_limit.rst
    webservices.rst
 

--- a/htdocs/index.php
+++ b/htdocs/index.php
@@ -158,6 +158,7 @@ $rrl_config = array(
     "max_per_ip"   => $max_attempts_per_ip,
     "per_time"     => $max_attempts_block_seconds,
     "dbdir"        => isset($ratelimit_dbdir) ? $ratelimit_dbdir : sys_get_temp_dir(),
+    "filter_by_ip" => isset($ratelimit_filter_by_ip_jsonfile) ? $ratelimit_filter_by_ip_jsonfile : ""
 );
 
 #==============================================================================


### PR DESCRIPTION
…o #631

- allow to specify by ip behavior of rate limit
  $ratelimit_filter_by_ip_jsonfile is parameter for json file content
  providing by ip mapping

  quick :
  to disable rate limit for one ip set "<ip>":{"per_time":"infinite"}
  in json file and reference it in $ratelimit_filter_by_ip_jsonfile variable
  within config.inc.local.php

  see doc config_rate_limit.rst for example.

- factorize ssp_rrl_users.json and ssp_rrl_ips.json parsing
  through a unique function updatedb_selector_count.