### PR TITLE
fix check password toward ldap attribute for token based methods issu…

### DIFF
--- a/htdocs/resetbyquestions.php
+++ b/htdocs/resetbyquestions.php
@@ -218,8 +218,8 @@ if ( $result === ""  || $populate_questions) {
                         }
                     }
 
-                    $entry = ldap_get_attributes($ldap, $entry);
-                    $entry['dn'] = $userdn;
+                    $entry_array = ldap_get_attributes($ldap, $entry);
+                    $entry_array['dn'] = $userdn;
                 }
             }
         }
@@ -236,7 +236,7 @@ if ( $result === "" ) {
 
 # Check password strength
 if ( $result === "" ) {
-    $result = check_password_strength( $newpassword, "", $pwd_policy_config, $login, $entry );
+    $result = check_password_strength( $newpassword, "", $pwd_policy_config, $login, $entry_array );
 }
 
 # Change password

--- a/htdocs/resetbytoken.php
+++ b/htdocs/resetbytoken.php
@@ -168,7 +168,8 @@ if ( $result === "" ) {
 
 # Check password strength
 if ( $result === "" ) {
-    $result = check_password_strength( $newpassword, "", $pwd_policy_config, $login, $entry );
+    $entry_array = ldap_get_attributes($ldap, $entry);
+    $result = check_password_strength( $newpassword, "", $pwd_policy_config, $login, $entry_array );
 }
 
 # Change password

--- a/lib/functions.inc.php
+++ b/lib/functions.inc.php
@@ -223,8 +223,9 @@ function show_policy( $messages, $pwd_policy_config, $result ) {
 }
 
 # Check password strength
+# @param array entry_array ldap entry ( ie not resource or LDAP\Result )
 # @return result code
-function check_password_strength( $password, $oldpassword, $pwd_policy_config, $login, $entry ) {
+function check_password_strength( $password, $oldpassword, $pwd_policy_config, $login, $entry_array ) {
     extract( $pwd_policy_config );
 
     $result = "";
@@ -313,9 +314,9 @@ function check_password_strength( $password, $oldpassword, $pwd_policy_config, $
     # Contains values from forbidden ldap fields?
     if ( !empty($pwd_forbidden_ldap_fields) ) {
         foreach ( $pwd_forbidden_ldap_fields as $field ) {
-            $values = $entry[$field];
-            if (!is_array($entry[$field])) {
-                $values = array($entry[$field]);
+            $values = $entry_array[$field];
+            if (!is_array($values)) {
+                $values = array($values);
             }
             foreach ($values as $key => $value) {
                 if ($key === 'count') {

--- a/tests/CheckPasswordTest.php
+++ b/tests/CheckPasswordTest.php
@@ -36,17 +36,17 @@ class CheckPasswordTest extends \PHPUnit_Framework_TestCase
 
         $login = "coudot";
         $oldpassword = "secret";
-        $entry = array('cn' => array('common name'), 'sn' => array('surname'));
+        $entry_array = array('cn' => array('common name'), 'sn' => array('surname'));
 
-        $this->assertEquals("sameaslogin", check_password_strength( "coudot", $oldpassword, $pwd_policy_config, $login, $entry ) );
-        $this->assertEquals("sameasold", check_password_strength( "secret", $oldpassword, $pwd_policy_config, $login, $entry ) );
-        $this->assertEquals("forbiddenchars", check_password_strength( "p@ssword", $oldpassword, $pwd_policy_config, $login, $entry ) );
-        $this->assertEquals("minspecial", check_password_strength( "password", $oldpassword, $pwd_policy_config, $login, $entry ) );
-        $this->assertEquals("mindigit", check_password_strength( "!password", $oldpassword, $pwd_policy_config, $login, $entry ) );
-        $this->assertEquals("minupper", check_password_strength( "!1password", $oldpassword, $pwd_policy_config, $login, $entry ) );
-        $this->assertEquals("minlower", check_password_strength( "!1PASSWORD", $oldpassword, $pwd_policy_config, $login, $entry ) );
-        $this->assertEquals("toobig", check_password_strength( "!1verylongPassword", $oldpassword, $pwd_policy_config, $login, $entry ) );
-        $this->assertEquals("tooshort", check_password_strength( "!1Pa", $oldpassword, $pwd_policy_config, $login, $entry ) );
+        $this->assertEquals("sameaslogin", check_password_strength( "coudot", $oldpassword, $pwd_policy_config, $login, $entry_array ) );
+        $this->assertEquals("sameasold", check_password_strength( "secret", $oldpassword, $pwd_policy_config, $login, $entry_array ) );
+        $this->assertEquals("forbiddenchars", check_password_strength( "p@ssword", $oldpassword, $pwd_policy_config, $login, $entry_array ) );
+        $this->assertEquals("minspecial", check_password_strength( "password", $oldpassword, $pwd_policy_config, $login, $entry_array ) );
+        $this->assertEquals("mindigit", check_password_strength( "!password", $oldpassword, $pwd_policy_config, $login, $entry_array ) );
+        $this->assertEquals("minupper", check_password_strength( "!1password", $oldpassword, $pwd_policy_config, $login, $entry_array ) );
+        $this->assertEquals("minlower", check_password_strength( "!1PASSWORD", $oldpassword, $pwd_policy_config, $login, $entry_array ) );
+        $this->assertEquals("toobig", check_password_strength( "!1verylongPassword", $oldpassword, $pwd_policy_config, $login, $entry_array ) );
+        $this->assertEquals("tooshort", check_password_strength( "!1Pa", $oldpassword, $pwd_policy_config, $login, $entry_array ) );
 
         $pwd_policy_config = array(
             "pwd_show_policy"         => true,
@@ -68,19 +68,19 @@ class CheckPasswordTest extends \PHPUnit_Framework_TestCase
             "pwd_forbidden_ldap_fields"=> array('cn', 'sn'),
         );
 
-        $this->assertEquals("notcomplex", check_password_strength( "simple", $oldpassword, $pwd_policy_config, $login, $entry ) );
-        $this->assertEquals("specialatends", check_password_strength( "!simple", $oldpassword, $pwd_policy_config, $login, $entry ) );
-        $this->assertEquals("specialatends", check_password_strength( "simple?", $oldpassword, $pwd_policy_config, $login, $entry ) );
-        $this->assertEquals("forbiddenwords", check_password_strength( "companyname", $oldpassword, $pwd_policy_config, $login, $entry ) );
-        $this->assertEquals("forbiddenwords", check_password_strength( "trademark", $oldpassword, $pwd_policy_config, $login, $entry ) );
-        $this->assertEquals("forbiddenwords", check_password_strength( "working at companyname is fun", $oldpassword, $pwd_policy_config, $login, $entry ) );
-        $this->assertEquals("forbiddenldapfields", check_password_strength( "common name", $oldpassword, $pwd_policy_config, $login, $entry ) );
-        $this->assertEquals("forbiddenldapfields", check_password_strength( "my surname", $oldpassword, $pwd_policy_config, $login, $entry ) );
-        $this->assertEquals("diffminchars", check_password_strength( "C0mplex", "C0mplexC0mplex", $pwd_policy_config, $login, $entry ) );
-        $this->assertEquals("", check_password_strength( "C0mplex", "", $pwd_policy_config, $login, $entry ) );
-        $this->assertEquals("", check_password_strength( "C0mplex", $oldpassword, $pwd_policy_config, $login, $entry ) );
-        $this->assertEquals("", check_password_strength( "C0!mplex", $oldpassword, $pwd_policy_config, $login, $entry ) );
-        $this->assertEquals("", check_password_strength( "%C0!mplex", $oldpassword, $pwd_policy_config, $login, $entry ) );
+        $this->assertEquals("notcomplex", check_password_strength( "simple", $oldpassword, $pwd_policy_config, $login, $entry_array ) );
+        $this->assertEquals("specialatends", check_password_strength( "!simple", $oldpassword, $pwd_policy_config, $login, $entry_array ) );
+        $this->assertEquals("specialatends", check_password_strength( "simple?", $oldpassword, $pwd_policy_config, $login, $entry_array ) );
+        $this->assertEquals("forbiddenwords", check_password_strength( "companyname", $oldpassword, $pwd_policy_config, $login, $entry_array ) );
+        $this->assertEquals("forbiddenwords", check_password_strength( "trademark", $oldpassword, $pwd_policy_config, $login, $entry_array ) );
+        $this->assertEquals("forbiddenwords", check_password_strength( "working at companyname is fun", $oldpassword, $pwd_policy_config, $login, $entry_array ) );
+        $this->assertEquals("forbiddenldapfields", check_password_strength( "common name", $oldpassword, $pwd_policy_config, $login, $entry_array ) );
+        $this->assertEquals("forbiddenldapfields", check_password_strength( "my surname", $oldpassword, $pwd_policy_config, $login, $entry_array ) );
+        $this->assertEquals("diffminchars", check_password_strength( "C0mplex", "C0mplexC0mplex", $pwd_policy_config, $login, $entry_array ) );
+        $this->assertEquals("", check_password_strength( "C0mplex", "", $pwd_policy_config, $login, $entry_array ) );
+        $this->assertEquals("", check_password_strength( "C0mplex", $oldpassword, $pwd_policy_config, $login, $entry_array ) );
+        $this->assertEquals("", check_password_strength( "C0!mplex", $oldpassword, $pwd_policy_config, $login, $entry_array ) );
+        $this->assertEquals("", check_password_strength( "%C0!mplex", $oldpassword, $pwd_policy_config, $login, $entry_array ) );
     }
 
     /**


### PR DESCRIPTION
…e #682

 - invalid type resource or LDAP\Result lead to notice or warning :
   'Trying to access array offset on value of type'
   - fix calls to enforce use of array
 - clarify call type of check_password_strength $user_array to be an array
 - to check this
   - use config : $pwd_forbidden_ldap_fields = array('sn');
   - reset by mail or by sms and use 'sn' content as your password
   - password should be refused.
   - no ''Trying to access array offset on value of type'
     should appear in logs