### PR TITLE
Fix reset by questions display after password change

### DIFF
--- a/templates/resetbyquestions.tpl
+++ b/templates/resetbyquestions.tpl
@@ -8,7 +8,7 @@
     <p><i class="fa fa-fw fa-exclamation-triangle" aria-hidden="true"></i> {$posthook_output[0]}</p>
     </div>
 {/if}
-{if $result !== 'sshkeychanged'}
+{if $result !== 'passwordchanged'}
     {if $show_help}
     <div class="help alert alert-warning">
     <p><i class="fa fa-fw fa-info-circle"></i> {$msg_resetbyquestionshelp|unescape: "html" nofilter}</p>


### PR DESCRIPTION
The form was still displayed even the password has been changed. This is now fixed.