### PR TITLE
Force password change with user in AD environments

### DIFF
--- a/conf/config.inc.php
+++ b/conf/config.inc.php
@@ -58,6 +58,8 @@ $ad_options['force_unlock'] = false;
 $ad_options['force_pwd_change'] = false;
 # Allow user with expired password to change password
 $ad_options['change_expired_password'] = false;
+# Force who_change_password to be 'user', useful in AD environments
+$ad_force_low_privileged_change = false;
 
 # Samba mode
 # true: update sambaNTpassword and sambaPwdLastSet attributes too

--- a/htdocs/change.php
+++ b/htdocs/change.php
@@ -172,6 +172,10 @@ if ( $result === "" ) {
                     }
                 }
 
+                if ($ad_force_low_privileged_change){
+                    $who_change_password = "user";
+                }
+
             }
         }
     }


### PR DESCRIPTION
I've added an option to force the password change in AD environments with the 'user' account even when the bind  has been done with the manager account.

The scenario is the following:
- The `ldap_binddn` which is used is low-privileged. Namely it cannot modify the password of the user (this is for security concerns)
- The user password is marked as `User must change password at next logon`

In this instance the bind with the user will fail but, even if `ldap_binddn` is low privileged they can change the user password  accordingly to Microsoft documentation (https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-adts/6e803168-f140-4d23-b2d3-c3a8ab5917d2):

> If the Modify request contains a delete operation containing a value Vdel for unicodePwd followed by an add operation containing a value Vadd for unicodePwd, the server considers the request to be a request to change the password. The server decodes Vadd and Vdel using the password decoding procedure documented later in this section. Vdel is the old password, while Vadd is the new password.


The change does the following:
- adds a configuration option `ad_force_low_privileged_change`
- if it is set to `true` it will force the `who_change_password` to `user` in `change.php`

This  allows the following flow to happen:
- The user is marked as `User must change password at next logon`
- change.php:
  - The code will take the branch at line 146
  - The code will re-bind with the (low-privileged) manger at line 163 
  - `$who_change_password` will be changed back to `user` at line 176
- functions.inc.php
  -  The code will take branch at line 457 and use the low-privileged manager bind to change the password for the user

The password change will work even without the need of an high-privilege user





