### PR TITLE
Catch user not found error

### DIFF
--- a/htdocs/changesshkey.php
+++ b/htdocs/changesshkey.php
@@ -98,12 +98,13 @@ if ( $result === "" ) {
 
                 # Get user DN
                 $entry = ldap_first_entry($ldap, $search);
-                $userdn = ldap_get_dn($ldap, $entry);
 
-                if ( !$userdn ) {
+                if ( !$entry ) {
                     $result = "badcredentials";
                     error_log("LDAP - User $login not found");
                 } else {
+
+                    $userdn = ldap_get_dn($ldap, $entry);
 
                     # Get user email for notification
                     if ($notify_on_sshkey_change) {

--- a/htdocs/resetbyquestions.php
+++ b/htdocs/resetbyquestions.php
@@ -138,12 +138,13 @@ if ( $result === ""  || $populate_questions) {
 
                 # Get user DN
                 $entry = ldap_first_entry($ldap, $search);
-                $userdn = ldap_get_dn($ldap, $entry);
 
-                if ( !$userdn ) {
+                if ( !$entry ) {
                     $result = "badcredentials";
                     error_log("LDAP - User $login not found");
                 } else {
+
+                    $userdn = ldap_get_dn($ldap, $entry);
 
                     # Check objectClass to allow samba and shadow updates
                     $ocValues = ldap_get_values($ldap, $entry, 'objectClass');

--- a/htdocs/resetbytoken.php
+++ b/htdocs/resetbytoken.php
@@ -134,26 +134,28 @@ if ( $result === "" ) {
 
                 # Get user DN
                 $entry = ldap_first_entry($ldap, $search);
-                $userdn = ldap_get_dn($ldap, $entry);
 
-                if( !$userdn ) {
+                if( !$entry ) {
                     $result = "badcredentials";
                     error_log("LDAP - User $login not found");
-                }
+                } else {
 
-                # Check objectClass to allow samba and shadow updates
-                $ocValues = ldap_get_values($ldap, $entry, 'objectClass');
-                if ( !in_array( 'sambaSamAccount', $ocValues ) and !in_array( 'sambaSAMAccount', $ocValues ) ) {
-                    $samba_mode = false;
-                }
-                if ( !in_array( 'shadowAccount', $ocValues ) ) {
-                    $shadow_options['update_shadowLastChange'] = false;
-                    $shadow_options['update_shadowExpire'] = false;
-                }
+                    $userdn = ldap_get_dn($ldap, $entry);
 
-                # Get user email for notification
-                if ($notify_on_change) {
-                    $mail = LtbAttributeValue::ldap_get_mail_for_notification($ldap, $entry);
+                    # Check objectClass to allow samba and shadow updates
+                    $ocValues = ldap_get_values($ldap, $entry, 'objectClass');
+                    if ( !in_array( 'sambaSamAccount', $ocValues ) and !in_array( 'sambaSAMAccount', $ocValues ) ) {
+                        $samba_mode = false;
+                    }
+                    if ( !in_array( 'shadowAccount', $ocValues ) ) {
+                        $shadow_options['update_shadowLastChange'] = false;
+                        $shadow_options['update_shadowExpire'] = false;
+                    }
+
+                    # Get user email for notification
+                    if ($notify_on_change) {
+                        $mail = LtbAttributeValue::ldap_get_mail_for_notification($ldap, $entry);
+		    }
                 }
             }
         }

--- a/htdocs/sendtoken.php
+++ b/htdocs/sendtoken.php
@@ -101,6 +101,12 @@ if ( $result === "" ) {
 
     # Get user DN
     $entry = ldap_first_entry($ldap, $search);
+
+    if( !$entry ) {
+        $result = "badcredentials";
+        error_log("LDAP - User $login not found");
+    } else {
+
     $userdn = ldap_get_dn($ldap, $entry);
 
     if( !$userdn ) {
@@ -155,7 +161,7 @@ if ( $result === "" ) {
         }
     }
 
-}}}}
+}}}}}
 
 #==============================================================================
 # Build and store token

--- a/htdocs/sendtoken.php
+++ b/htdocs/sendtoken.php
@@ -107,12 +107,8 @@ if ( $result === "" ) {
         error_log("LDAP - User $login not found");
     } else {
 
-    $userdn = ldap_get_dn($ldap, $entry);
+        $userdn = ldap_get_dn($ldap, $entry);
 
-    if( !$userdn ) {
-        $result = "badcredentials";
-        error_log("LDAP - User $login not found");
-    } else {
         # Compare mail values
         $entry_attributes = ldap_get_attributes($ldap, $entry);
         for ($match = false, $i = 0; $i < sizeof($mail_attributes) and ! $match; $i++) {
@@ -161,7 +157,7 @@ if ( $result === "" ) {
         }
     }
 
-}}}}}
+}}}}
 
 #==============================================================================
 # Build and store token

--- a/htdocs/setquestions.php
+++ b/htdocs/setquestions.php
@@ -117,12 +117,13 @@ if ( $result === "" ) {
 
     # Get user DN
     $entry = ldap_first_entry($ldap, $search);
-    $userdn = ldap_get_dn($ldap, $entry);
 
-    if( !$userdn ) {
+    if( !$entry ) {
         $result = "badcredentials";
         error_log("LDAP - User $login not found");
     } else {
+
+    $userdn = ldap_get_dn($ldap, $entry);
 
     # Bind with password
     $bind = ldap_bind($ldap, $userdn, $password);


### PR DESCRIPTION
We were missing a lot of files when `ldap_get_dn` was called whithout checking that `$entry` was not null. Should be ok with these patches.