### PR TITLE
captcha in sendsms check when needed only fix #720

### DIFF
--- a/htdocs/sendsms.php
+++ b/htdocs/sendsms.php
@@ -38,15 +38,7 @@ $token = "";
 $sessiontoken = "";
 $attempts = 0;
 
-#==============================================================================
-# Check captcha
-#==============================================================================
-if ($use_captcha) { $result = global_captcha_check();}
-
-if (! ($result === "") ) {
-    # result was already set
-    # done this way to keep indentation
-} elseif (!$crypt_tokens) {
+if (!$crypt_tokens) {
     $result = "crypttokensrequired";
 } elseif (isset($_REQUEST["smstoken"]) and isset($_REQUEST["token"])) {
     $token = strval($_REQUEST["token"]);
@@ -106,9 +98,15 @@ if (! ($result === "") ) {
     $result = "emptysendsmsform";
 }
 
-# Check the entered username for characters that our installation doesn't support
 if ( $result === "" ) {
-    $result = check_username_validity($login,$login_forbidden_chars);
+    # Check captcha
+    if ($use_captcha) {
+        $result = global_captcha_check();
+    }
+    # Check the entered username for characters that our installation doesn't support
+    if (  $result === "" ) {
+        $result = check_username_validity($login,$login_forbidden_chars);
+    }
 }
 
 #==============================================================================
@@ -261,7 +259,6 @@ if ( $result === "sendsms" ) {
             }
         }
     }
-
 }
 
 #==============================================================================


### PR DESCRIPTION
- revert to previous behavior of sendsms to place captcha check.
  - sendsms is called mutliple times during sms sending process one the first need captcha check.

- was a regression of #680