### PR TITLE
Use gpg instead of apt-key during for deb install

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -39,13 +39,19 @@ Configure the repository:
 
 .. code-block:: ini
 
-    deb [arch=amd64] https://ltb-project.org/debian/stable stable main
+    deb [arch=amd64 signed-by=/etc/apt/keyrings/ltb-project.gpg] https://ltb-project.org/debian/stable stable main
+
+Create repository key folder, if it doesn't exist:
+
+.. prompt:: bash #
+
+    sudo mkdir -p /etc/apt/keyrings
 
 Import repository key:
 
 .. prompt:: bash #
 
-    wget -O - https://ltb-project.org/documentation/_static/RPM-GPG-KEY-LTB-project | sudo apt-key add -
+    wget -O - https://ltb-project.org/documentation/_static/RPM-GPG-KEY-LTB-project | gpg --dearmor -o /etc/apt/keyrings/ltb-project.gpg
 
 Then update:
 


### PR DESCRIPTION
apt-key is deprecated (see apt-key(8)), use of a gpg keyring should be used.