### PR TITLE
[Fix] Direct user to root url without index.php

### DIFF
--- a/templates/menu.tpl
+++ b/templates/menu.tpl
@@ -8,7 +8,7 @@
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
               </button>
-              <a class="navbar-brand" href="index.php{if $default_action != 'change'}?action=change{/if}">
+              <a class="navbar-brand" href=".{if $default_action != 'change'}?action=change{/if}">
                 {if $logo}
                 <img src="{$logo}" alt="Logo" class="menu-logo img-responsive" />
                 {/if}


### PR DESCRIPTION
Hi ltb-project,

I found the brand link in menu.tpl uses a link containing index.php.
For example, suppose you installed this app at https://example.com/ssp/, the link direct users to https://example.com/ssp/index.php.

I fixed this link by updating href attribute in the following way. The updated link can direct users to the ssp's root url **without** index.php prefix.

Before: ```href="index.php{if $default_action != 'change'}?action=change{/if}"```
After: ```href=".{if $default_action != 'change'}?action=change{/if}"```

I hope you merge this request.
Kind regards,