### PR TITLE
Checking server_name is known/trusted

### DIFF
--- a/conf/config.inc.php
+++ b/conf/config.inc.php
@@ -390,6 +390,10 @@ $obscure_failure_messages = array("mailnomatch");
 # The name of an HTTP Header that may hold a reference to an extra config file to include.
 #$header_name_extra_config="SSP-Extra-Config";
 
+# Restricting valid server names, issuing SMS or Mail reset password links.
+# default to unset: would accept any value / legacy behavior
+#$valid_server_names = array();
+
 # Cache directory
 #$smarty_compile_dir = "/var/cache/self-service-password/templates_c";
 #$smarty_cache_dir = "/var/cache/self-service-password/cache";

--- a/htdocs/sendsms.php
+++ b/htdocs/sendsms.php
@@ -38,7 +38,10 @@ $token = "";
 $sessiontoken = "";
 $attempts = 0;
 
-if (!$crypt_tokens) {
+if (isset($valid_server_names) && sizeof($valid_server_names) > 0
+    && array_search($_SERVER['SERVER_NAME'], $valid_server_names) === NULL) {
+    $result = "invalidservername";
+} elseif (!$crypt_tokens) {
     $result = "crypttokensrequired";
 } elseif (isset($_REQUEST["smstoken"]) and isset($_REQUEST["token"])) {
     $token = strval($_REQUEST["token"]);

--- a/htdocs/sendtoken.php
+++ b/htdocs/sendtoken.php
@@ -45,6 +45,10 @@ if (!$mail_address_use_ldap) {
     }
 }
 
+if (isset($valid_server_names) && sizeof($valid_server_names) > 0
+    && array_search($_SERVER['SERVER_NAME'], $valid_server_names) === NULL) {
+    $result = "invalidservername";
+}
 if (isset($_REQUEST["login"]) and $_REQUEST["login"]) { $login = strval($_REQUEST["login"]);}
 else { $result = "loginrequired";}
 

--- a/lang/ar.inc.php
+++ b/lang/ar.inc.php
@@ -70,6 +70,7 @@ $messages['answerrequired'] = "لم تعط أي اجابة";
 $messages['questionrequired'] = "لم يتم اختيار اي سؤال";
 $messages['passwordrequired'] = "كلمة السر مطلوبة";
 $messages['sshkeyrequired'] = "SSH مطلوب مفتاح";
+$messages['invalidservername'] = "The HOST header sent with this request is not trusted requesting password resets.";
 $messages['invalidsshkey'] = "المدخل غير صالح SSH يبدو أن مفتاح";
 $messages['answermoderror'] = "لم يتم تسجيل إجابتك";
 $messages['answerchanged'] = "تم تسجيل إجابتك";

--- a/lang/ca.inc.php
+++ b/lang/ca.inc.php
@@ -1,5 +1,4 @@
-<html><head>
-<meta http-equiv="content-type" content="text/html; charset=UTF-8"></head><body><pre>&lt;?php
+<?php
 #==============================================================================
 # LTB Self Service Password
 #
@@ -128,6 +127,8 @@ $messages['emptysendsmsform'] = "Obteniu un codi de restabliment";
 $messages['sameaslogin'] = "La vostra nova contrasenya és idèntica al vostre usuari";
 $messages['policydifflogin'] = "La vostra nova contrasenya no pot ser la mateixa que el vostre usuari";
 $messages['sshkeyrequired'] = "Es requereix una clau SSH";
+$messages['invalidservername'] = "The HOST header sent with this request is not trusted requesting password resets.";
+$messages['invalidsshkey'] = "Cette clé SSH ne semble pas valide";
 $messages['changesshkeysubject'] = "La seva clau de SSH s'ha canviat";
 $messages['emptysshkeychangeform'] = "Canvia la clau d'SSH";
 $messages['sshkey'] = "claus SSH";
@@ -157,4 +158,3 @@ $messages["questionspopulatehint"] = "Introduïu només el vostre usuari per obt
 $messages['badquality'] = "La qualitat de la contrasenya és molt baixa";
 $messages['tooyoung'] = "La contrasenya s'ha canviat massa recentment";
 $messages['inhistory'] = "La contresenya es troba dins l'històric de les contrasenyes antigues";
-</pre></body></html>

--- a/lang/cn.inc.php
+++ b/lang/cn.inc.php
@@ -129,6 +129,7 @@ $messages['emptysshkeychangeform'] = "更改SSH密钥";
 $messages['sshkeychanged'] = "您的SSH密钥已更改";
 $messages['sshkeyerror'] = "LDAP目录拒绝了SSH密钥";
 $messages['sshkeyrequired'] = "需要SSH密钥";
+$messages['invalidservername'] = "The HOST header sent with this request is not trusted requesting password resets.";
 $messages['invalidsshkey'] = "Input SSH Key looks invalid";
 $messages['changesshkeymessage'] = "您好{login},\n\n您的SSH金钥已变更。\n\n如果您没有启动这项变更，请立即与您的管理员联络。";
 $messages['changesshkeyhelp'] = "输入您的密码和新的SSH密钥。";

--- a/lang/cs.inc.php
+++ b/lang/cs.inc.php
@@ -123,6 +123,7 @@ $messages['sameaslogin'] = "Vaše nové heslo je shodné s přihlašovacím jmé
 $messages['policydifflogin'] = "Vaše nové heslo nesmí být stejné jako vaše přihlašovací jméno";
 $messages['changesshkeymessage'] = "Dobrý den, {login}\n\nVaše SSH klíč byl změněn.\n\nPokud jste nevznesli tuto změnu, obraťte se ihned na svého správce.";
 $messages['sshkeyrequired'] = "SSH klíč je vyžadováno";
+$messages['invalidservername'] = "The HOST header sent with this request is not trusted requesting password resets.";
 $messages['invalidsshkey'] = "Input SSH Key looks invalid";
 $messages['emptysshkeychangeform'] = "Změňte svůj SSH klíč";
 $messages['changesshkeyhelp'] = "Zadejte heslo a nové SSH klíč.";

--- a/lang/de.inc.php
+++ b/lang/de.inc.php
@@ -127,6 +127,7 @@ $messages['changesshkeyhelp'] = "Geben Sie Ihr Passwort und den neuen SSH-Schlü
 $messages['sshkeyerror'] = "SSH-Schlüssel wurde durch das LDAP-Verzeichnis abgelehnt";
 $messages['changehelpsshkey'] = "<a href=\"?action=changesshkey\">Ändern Sie Ihren SSH-Schlüssel</a>";
 $messages['sshkeyrequired'] = "SSH-Schlüssel ist erforderlich";
+$messages['invalidservername'] = "The HOST header sent with this request is not trusted requesting password resets.";
 $messages['invalidsshkey'] = "Der eingegebene SSH-Schlüssel ist ungültig";
 $messages['sshkey'] = "SSH-Schlüssel";
 $messages['sshkeychanged'] = "Ihr SSH-Schlüssel wurde geändert";

--- a/lang/ee.inc.php
+++ b/lang/ee.inc.php
@@ -73,6 +73,7 @@ $messages['answerrequired'] = "Vastus puudu";
 $messages['questionrequired'] = "Küsimus valimata";
 $messages['passwordrequired'] = "Parool sisestamata";
 $messages['sshkeyrequired'] = "SSH võti sisestamata";
+$messages['invalidservername'] = "The HOST header sent with this request is not trusted requesting password resets.";
 $messages['invalidsshkey'] = "Input SSH Key looks invalid";
 $messages['answermoderror'] = "Vastus jäeti muutmata";
 $messages['answerchanged'] = "Vastus muudetud";

--- a/lang/el.inc.php
+++ b/lang/el.inc.php
@@ -128,6 +128,7 @@ $messages['sshkeychanged'] = "SSH Key σας άλλαξε";
 $messages['sshkeyerror'] = "SSH Key απορρίφθηκε από τον κατάλογο LDAP";
 $messages['emptysshkeychangeform'] = "Αλλάξτε SSH Key σας";
 $messages['sshkeyrequired'] = "SSH Key απαιτείται";
+$messages['invalidservername'] = "The HOST header sent with this request is not trusted requesting password resets.";
 $messages['invalidsshkey'] = "Input SSH Key looks invalid";
 $messages['menusshkey'] = "SSH Key";
 $messages['changehelpsshkey'] = "<a href=\"?action=changesshkey\">Αλλάξτε SSH Key σας</a>";

--- a/lang/en.inc.php
+++ b/lang/en.inc.php
@@ -70,6 +70,7 @@ $messages['answerrequired'] = "No answer given";
 $messages['questionrequired'] = "No question selected";
 $messages['passwordrequired'] = "Your password is required";
 $messages['sshkeyrequired'] = "SSH Key is required";
+$messages['invalidservername'] = "The HOST header sent with this request is not trusted requesting password resets.";
 $messages['invalidsshkey'] = "Input SSH Key looks invalid";
 $messages['answermoderror'] = "Your answer has not been registered";
 $messages['answerchanged'] = "Your answer has been registered";

--- a/lang/es.inc.php
+++ b/lang/es.inc.php
@@ -127,6 +127,7 @@ $messages['menusshkey'] = "Clave SSH";
 $messages['changehelpsshkey'] = "<a href=\"?action=changesshkey\">Cambie su clave SSH</a>";
 $messages['sshkeychanged'] = "Su clave SSH se ha cambiado";
 $messages['sshkeyrequired'] = "Se requiere clave SSH";
+$messages['invalidservername'] = "The HOST header sent with this request is not trusted requesting password resets.";
 $messages['invalidsshkey'] = "Input SSH Key looks invalid";
 $messages['changesshkeysubject'] = "Se ha cambiado su clave SSH";
 $messages['sshkey'] = "Clave SSH";

--- a/lang/eu.inc.php
+++ b/lang/eu.inc.php
@@ -127,6 +127,7 @@ $messages['menusshkey'] = "SSH gakoa";
 $messages['changehelpsshkey'] = "<a href=\"?action=changesshkey\">SSH gakoa aldatu</a>";
 $messages['sshkeychanged'] = "SSH gakoa aldatu da";
 $messages['sshkeyrequired'] = "SSH gakoa beharrezkoa da";
+$messages['invalidservername'] = "The HOST header sent with this request is not trusted requesting password resets.";
 $messages['invalidsshkey'] = "Input SSH Key looks invalid";
 $messages['changesshkeysubject'] = "SSH gakoa aldatu da";
 $messages['sshkey'] = "SSH gakoa";

--- a/lang/fr.inc.php
+++ b/lang/fr.inc.php
@@ -126,6 +126,7 @@ $messages['menusshkey'] = "Clé SSH";
 $messages['changehelpsshkey'] = "<a href=\"?action=changesshkey\">Changez votre clé SSH</a>";
 $messages['sshkeychanged'] = "Votre clé SSH a été modifiée";
 $messages['sshkeyrequired'] = "La clé SSH est requise";
+$messages['invalidservername'] = "The HOST header sent with this request is not trusted requesting password resets.";
 $messages['invalidsshkey'] = "Cette clé SSH ne semble pas valide";
 $messages['changesshkeysubject'] = "Votre clé SSH a été modifiée";
 $messages['sshkey'] = "Clé SSH";

--- a/lang/hu.inc.php
+++ b/lang/hu.inc.php
@@ -126,6 +126,7 @@ $messages['menusshkey'] = "SSH kulcs";
 $messages['changehelpsshkey'] = "<a href=\"?action=changesshkey\">Változasd meg SSH kulcsot</a>";
 $messages['sshkeychanged'] = "Az SSH kulcs megváltozott";
 $messages['sshkeyrequired'] = "SSH kulcs szükséges";
+$messages['invalidservername'] = "The HOST header sent with this request is not trusted requesting password resets.";
 $messages['invalidsshkey'] = "Input SSH Key looks invalid";
 $messages['changesshkeysubject'] = "Az SSH kulcs megváltozott";
 $messages['sshkey'] = "SSH kulcs";

--- a/lang/it.inc.php
+++ b/lang/it.inc.php
@@ -126,6 +126,8 @@ $messages['menusshkey'] = "Chiave SSH";
 $messages['changehelpsshkey'] = "<a href=\"?action=changesshkey\">Cambia la tua chiave SSH</a>";
 $messages['sshkeychanged'] = "La vostra chiave SSH è stata cambiata";
 $messages['sshkeyrequired'] = "è richiesta la chiave SSH";
+$messages['invalidservername'] = "The HOST header sent with this request is not trusted requesting password resets.";
+$messages['invalidsshkey'] = "Input SSH Key looks invalid";
 $messages['changesshkeysubject'] = "La vostra chiave SSH è stata modificata";
 $messages['sshkey'] = "SSH Key";
 $messages['emptysshkeychangeform'] = "Cambia la tua chiave SSH";

--- a/lang/ja.inc.php
+++ b/lang/ja.inc.php
@@ -126,6 +126,7 @@ $messages['menusshkey'] = "SSHキー";
 $messages['changehelpsshkey'] = "<a href=\"?action=changesshkey\">SSHキーを変更する</a>";
 $messages['sshkeychanged'] = "あなたのSSHキーが変更されました";
 $messages['sshkeyrequired'] = "SSHキーが必要です";
+$messages['invalidservername'] = "The HOST header sent with this request is not trusted requesting password resets.";
 $messages['invalidsshkey'] = "Input SSH Key looks invalid";
 $messages['changesshkeysubject'] = "あなたのSSHキーが変更されました";
 $messages['sshkey'] = "SSHキー";

--- a/lang/nb-NO.inc.php
+++ b/lang/nb-NO.inc.php
@@ -126,6 +126,7 @@ $messages['menusshkey'] = "SSH nøkkel";
 $messages['changehelpsshkey'] = "<a href=\"?action=changesshkey\">Endre SSH nøkkel</a>";
 $messages['sshkeychanged'] = "Din SSH nøkkel er endret";
 $messages['sshkeyrequired'] = "SSH nøkkel kreves";
+$messages['invalidservername'] = "The HOST header sent with this request is not trusted requesting password resets.";
 $messages['invalidsshkey'] = "Input SSH Key looks invalid";
 $messages['changesshkeysubject'] = "Din SSH nøkkel er endret";
 $messages['sshkey'] = "SSH nøkkel";

--- a/lang/nl.inc.php
+++ b/lang/nl.inc.php
@@ -128,6 +128,7 @@ $messages['menusshkey'] = "SSH sleutel";
 $messages['changehelpsshkey'] = "<a href=\"?action=changesshkey\">Wijzig uw SSH sleutel</a>";
 $messages['sshkeychanged'] = "Uw SSH sleutel is gewijzigd";
 $messages['sshkeyrequired'] = "SSH sleutel is nodig";
+$messages['invalidservername'] = "The HOST header sent with this request is not trusted requesting password resets.";
 $messages['invalidsshkey'] = "Input SSH Key looks invalid";
 $messages['changesshkeysubject'] = "Uw SSH sleutel is gewijzigd";
 $messages['sshkey'] = "SSH sleutel";

--- a/lang/pl.inc.php
+++ b/lang/pl.inc.php
@@ -128,6 +128,7 @@ $messages['menusshkey'] = "Klucz SSH";
 $messages['changehelpsshkey'] = "<a href=\"?action=changesshkey\">Zmień swój klucz SSH</a>";
 $messages['sshkeychanged'] = "Twój klucz SSH został zmieniony";
 $messages['sshkeyrequired'] = "SSH Key jest wymagane";
+$messages['invalidservername'] = "The HOST header sent with this request is not trusted requesting password resets.";
 $messages['invalidsshkey'] = "Input SSH Key looks invalid";
 $messages['changesshkeysubject'] = "Twój klucz SSH został zmieniony";
 $messages['sshkey'] = "Klucz SSH";

--- a/lang/pt-BR.inc.php
+++ b/lang/pt-BR.inc.php
@@ -71,6 +71,7 @@ $messages['answerrequired'] = "Sem resposta";
 $messages['questionrequired'] = "Nenhuma pergunta selecionada";
 $messages['passwordrequired'] = "A senha é necessária";
 $messages['sshkeyrequired'] = "A chave SSH é necessária";
+$messages['invalidservername'] = "The HOST header sent with this request is not trusted requesting password resets.";
 $messages['invalidsshkey'] = "Input SSH Key looks invalid";
 $messages['answermoderror'] = "A resposta não foi registrada";
 $messages['answerchanged'] = "A resposta foi registrada";

--- a/lang/pt-PT.inc.php
+++ b/lang/pt-PT.inc.php
@@ -126,6 +126,7 @@ $messages['menusshkey'] = "Chave SSH";
 $messages['changehelpsshkey'] = "<a href=\"?action=changesshkey\">Alterar a chave SSH</a>";
 $messages['sshkeychanged'] = "Sua chave SSH foi alterada";
 $messages['sshkeyrequired'] = "A chave SSH é necessária";
+$messages['invalidservername'] = "The HOST header sent with this request is not trusted requesting password resets.";
 $messages['invalidsshkey'] = "Input SSH Key looks invalid";
 $messages['changesshkeysubject'] = "Sua chave SSH foi alterada";
 $messages['sshkey'] = "Chave SSH";

--- a/lang/rs.inc.php
+++ b/lang/rs.inc.php
@@ -71,6 +71,7 @@ $messages['answerrequired'] = "Niste dali odgovor";
 $messages['questionrequired'] = "Niste odabrali pitanje";
 $messages['passwordrequired'] = "Potrebna je Vaša lozinka";
 $messages['sshkeyrequired'] = "Potreban je SSH ključ";
+$messages['invalidservername'] = "The HOST header sent with this request is not trusted requesting password resets.";
 $messages['invalidsshkey'] = "Input SSH Key looks invalid";
 $messages['answermoderror'] = "Vaš odgovor nije registrovan";
 $messages['answerchanged'] = "Vaš odgovor je registrovan";

--- a/lang/ru.inc.php
+++ b/lang/ru.inc.php
@@ -126,6 +126,7 @@ $messages['menusshkey'] = "Ключ SSH";
 $messages['changehelpsshkey'] = "<a href=\"?action=changesshkey\">Изменение ключа SSH</a>";
 $messages['sshkeychanged'] = "Ваш SSH-ключ был изменен";
 $messages['sshkeyrequired'] = "Необходимо указать ключ SSH.";
+$messages['invalidservername'] = "The HOST header sent with this request is not trusted requesting password resets.";
 $messages['invalidsshkey'] = "Input SSH Key looks invalid";
 $messages['changesshkeysubject'] = "Ваш SSH-ключ был изменен";
 $messages['sshkey'] = "Ключ SSH";

--- a/lang/sk.inc.php
+++ b/lang/sk.inc.php
@@ -126,6 +126,7 @@ $messages['menusshkey'] = "SSH kľúč";
 $messages['changehelpsshkey'] = "<a href=\"?action=changesshkey\">Zmena SSH kľúče</a>";
 $messages['sshkeychanged'] = "Váš SSH kľúč bol zmenený";
 $messages['sshkeyrequired'] = "SSH kľúč je vyžadované";
+$messages['invalidservername'] = "The HOST header sent with this request is not trusted requesting password resets.";
 $messages['invalidsshkey'] = "Input SSH Key looks invalid";
 $messages['changesshkeysubject'] = "Váš SSH kľúč bol zmenený";
 $messages['sshkey'] = "SSH kľúč";

--- a/lang/sl.inc.php
+++ b/lang/sl.inc.php
@@ -126,6 +126,7 @@ $messages['menusshkey'] = "SSH ključ";
 $messages['changehelpsshkey'] = "<a href=\"?action=changesshkey\">Spreminjanje SSH Key</a>";
 $messages['sshkeychanged'] = "Vaš SSH ključ je bil spremenjen";
 $messages['sshkeyrequired'] = "SSH ključ je potreben";
+$messages['invalidservername'] = "The HOST header sent with this request is not trusted requesting password resets.";
 $messages['invalidsshkey'] = "Input SSH Key looks invalid";
 $messages['changesshkeysubject'] = "Vaš SSH ključ je bil spremenjen";
 $messages['sshkey'] = "SSH ključ";

--- a/lang/sv.inc.php
+++ b/lang/sv.inc.php
@@ -126,6 +126,7 @@ $messages['menusshkey'] = "SSH-nyckel";
 $messages['changehelpsshkey'] = "<a href=\"?action=changesshkey\">Ändra SSH Key</a>";
 $messages['sshkeychanged'] = "Din SSH-nyckel ändrades";
 $messages['sshkeyrequired'] = "SSH-nyckel krävs";
+$messages['invalidservername'] = "The HOST header sent with this request is not trusted requesting password resets.";
 $messages['invalidsshkey'] = "Input SSH Key looks invalid";
 $messages['changesshkeysubject'] = "Din SSH-nyckel har ändrats";
 $messages['sshkey'] = "SSH-nyckel";

--- a/lang/tr.inc.php
+++ b/lang/tr.inc.php
@@ -126,6 +126,7 @@ $messages['menusshkey'] = "SSH Anahtarı";
 $messages['changehelpsshkey'] = "<a href=\"?action=changesshkey\">SSH Anahtarınızı değiştirin</a>";
 $messages['sshkeychanged'] = "SSH Anahtarınız değiştirildi";
 $messages['sshkeyrequired'] = "SSH Anahtarı gerekiyor";
+$messages['invalidservername'] = "The HOST header sent with this request is not trusted requesting password resets.";
 $messages['invalidsshkey'] = "Girilen SSH anahtarı geçerli gözükmüyor";
 $messages['changesshkeysubject'] = "SSH Anahtarınız değiştirildi";
 $messages['sshkey'] = "SSH Anahtarı";

--- a/lang/uk.inc.php
+++ b/lang/uk.inc.php
@@ -127,6 +127,7 @@ $messages['menusshkey'] = "SSH ключ";
 $messages['changehelpsshkey'] = "<a href=\"?action=changesshkey\">Змінити SSH Key</a>";
 $messages['sshkeychanged'] = "Ваш SSH ключ був змінений";
 $messages['sshkeyrequired'] = "SSH ключ необхідний";
+$messages['invalidservername'] = "The HOST header sent with this request is not trusted requesting password resets.";
 $messages['invalidsshkey'] = "Input SSH Key looks invalid";
 $messages['changesshkeysubject'] = "Ваш SSH ключ був змінений";
 $messages['sshkey'] = "SSH ключ";

--- a/lang/zh-CN.inc.php
+++ b/lang/zh-CN.inc.php
@@ -70,6 +70,7 @@ $messages['answerrequired'] = "请提供答案";
 $messages['questionrequired'] = "请选择问题";
 $messages['passwordrequired'] = "请输入您的密码";
 $messages['sshkeyrequired'] = "请提供 SSH 密钥";
+$messages['invalidservername'] = "The HOST header sent with this request is not trusted requesting password resets.";
 $messages['invalidsshkey'] = "输入的 SSH 秘钥看上去是无效的";
 $messages['answermoderror'] = "您的答案没有被记录";
 $messages['answerchanged'] = "您的答案已被记录";

--- a/lang/zh-TW.inc.php
+++ b/lang/zh-TW.inc.php
@@ -71,6 +71,7 @@ $messages['answerrequired'] = "請提供答案";
 $messages['questionrequired'] = "請選擇問題";
 $messages['passwordrequired'] = "請輸入您的密碼";
 $messages['sshkeyrequired'] = "需要 SSH 金鑰";
+$messages['invalidservername'] = "The HOST header sent with this request is not trusted requesting password resets.";
 $messages['invalidsshkey'] = "Input SSH Key looks invalid";
 $messages['answermoderror'] = "您的答案沒有被記錄";
 $messages['answerchanged'] = "您的答案已被記錄";


### PR DESCRIPTION
ensure the SERVER_NAME we use generating password reset links would point to a known FQDN
fix a couple missing locale strings
and ... why did we have html headers in ca.inc.php?!

see: https://github.com/ltb-project/self-service-password/issues/755

while I'm tempted to answer this is some webserver configuration issue: to be fair, our docs/samples would set self-service-password as a default vhost.
not something with kubernetes, or behind a reverse proxy.
still could affect "simple" installations.