### PR TITLE
Announce that the smarty3 package needs to be installed manually

### DIFF
--- a/packaging/debian/NEWS
+++ b/packaging/debian/NEWS
@@ -1,0 +1,14 @@
+ltb-project-self-service-password (1.5.3-2) unstable; urgency=high
+
+  Smarty3 package must be manually installed
+
+  Smarty3 package, on which this software relies, is currently broken
+  on Ubuntu, so it was removed from packages dependences since
+  version 1.5.3-1.
+  Install smarty3 package manually and follow instructions on
+  https://self-service-password.readthedocs.io/en/latest/installation.html#debian-ubuntu
+  if you face this error:
+
+    syntax error, unexpected token "class"
+
+ -- Clement Oudot <clem@ltb-project.org>  Wed, 17 May 2023 12:18:22 +0200

--- a/packaging/debian/self-service-password.config
+++ b/packaging/debian/self-service-password.config
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+
+. /usr/share/debconf/confmodule || exit 0
+
+db_input critical self-service-password/smarty-warn || true
+db_go

--- a/packaging/debian/self-service-password.postinst
+++ b/packaging/debian/self-service-password.postinst
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+. /usr/share/debconf/confmodule
+
 # Move configuration for older version
 if [ -r "/usr/share/self-service-password/config.inc.php" ]; then
     mv /usr/share/self-service-password/config.inc.php /usr/share/self-service-password/conf/config.inc.php

--- a/packaging/debian/self-service-password.templates
+++ b/packaging/debian/self-service-password.templates
@@ -1,0 +1,12 @@
+
+Template: self-service-password/smarty-warn
+Type: note
+Description: Smarty3 package must be manually installed
+ Smarty3 package, on which this software relies, is currently broken
+ on Ubuntu, so it was removed from packages dependences since
+ version 1.5.3-1.
+ Install smarty3 package manually and follow instructions on
+ https://self-service-password.readthedocs.io/en/latest/installation.html#debian-ubuntu
+ if you face this error:
+ .
+   syntax error, unexpected token "class"


### PR DESCRIPTION
This PR is tied to the #773 issue.

I added 2 commits to announce that the smarty3 package needs to be installed manually, one through the NEWS file and the other through the debconf note.

I added the debconf note, while is not the preferred method, as the first can pass unnoticed  if apt-listchanges is not installed.

They are independent, so you can took only one or both.

I needed to insert a version in the NEWS file, I choose 1.5.3-2 for test, feel free change it to make it compliant with your policy.