### PR TITLE
Use login_hint to prefill user login

### DIFF
--- a/docs/config_general.rst
+++ b/docs/config_general.rst
@@ -259,13 +259,18 @@ Prefill user login
 ------------------
 
 If Self Service Password is called from another application, you can
-prefill the login but sending an HTTP header.
+prefill the login by sending an HTTP header.
 
-To enable this feature:
+To enable this feature, configure the name of the HTTP header:
 
 .. code-block:: php
 
    $header_name_preset_login = "Auth-User";
+
+It is also possible to prefill the login by using the ``login_hint``
+GET or POST parameter. This method does not require any configuration.
+
+Example: ``https://ssp.example.com/?actionresetbyquestions&login_hint=spiderman``
 
 Captcha
 -------

--- a/htdocs/index.php
+++ b/htdocs/index.php
@@ -151,6 +151,9 @@ $rrl_config = array(
     "filter_by_ip" => isset($ratelimit_filter_by_ip_jsonfile) ? $ratelimit_filter_by_ip_jsonfile : ""
 );
 
+# Preset login with login_hint
+if (isset($_REQUEST["login_hint"]) and $_REQUEST["login_hint"]) { $presetLogin = strval($_REQUEST["login_hint"]); }
+
 #==============================================================================
 # Route to action
 #==============================================================================


### PR DESCRIPTION
We had the possibility to prefill login with an HTTP header.

This PR adds the possibility to prefill login with the `login_hint` GET/POST parameter.

Resolves #780 