### PR TITLE
explicitly use docker image with Debian 11

### DIFF
--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.1-apache
+FROM php:8.1-apache-bullseye
 # Install PHP extensions and PECL modules.
 RUN buildDeps=" \
         libbz2-dev \


### PR DESCRIPTION
apparently the Debian Version in the php:8.1-apache image has been changed to Debian 12. Some runtime dependencies, like libwebp6 are not available in  Debian 12. Therefore the php image tag should be changed to use Debian 11 explicitly.