### PR TITLE
Dockerfile fails to build #813

### DIFF
--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -18,7 +18,7 @@ RUN buildDeps=" \
 	libgd3 \
 	libjpeg62-turbo \
 	libpng16-16 \
-	libwebp6 \
+	libwebp7 \
         libzip-dev \
 	locales \
 	locales-all \
@@ -27,7 +27,7 @@ RUN buildDeps=" \
     && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y $buildDeps $runtimeDeps \
     && docker-php-ext-install bcmath bz2 iconv intl mbstring opcache curl \
     && docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp \
-    && docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ \
+    && docker-php-ext-configure ldap \
     && docker-php-ext-install ldap gd \
     && echo en_US.UTF-8 UTF-8 >/etc/locale.gen \
     && /usr/sbin/locale-gen \

--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -27,7 +27,7 @@ RUN buildDeps=" \
     && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y $buildDeps $runtimeDeps \
     && docker-php-ext-install bcmath bz2 iconv intl mbstring opcache curl \
     && docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp \
-    && docker-php-ext-configure ldap \
+    && docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ \
     && docker-php-ext-install ldap gd \
     && echo en_US.UTF-8 UTF-8 >/etc/locale.gen \
     && /usr/sbin/locale-gen \


### PR DESCRIPTION
Upgrading to libwebp7 to resolve missing package error with base image upgrading to Debian 12.  Fix for https://github.com/ltb-project/self-service-password/issues/813

This was included in my original PR, but has been removed:
Removing `--with-libdir=` option on php configure ldap that was causing build failure. I do not know PHP well enough to know what the `--with-libdir=lib/x86_64-linux-gnu/` was doing, but removing resolved docker build failures.  The resulting docker image tests successfully within my target environment.
