### PR TITLE
checkentropy js: use known path, ie when behind a reverse proxy

### DIFF
--- a/htdocs/js/ppolicy.js
+++ b/htdocs/js/ppolicy.js
@@ -236,7 +236,7 @@
       if (newpasswordVal.length > 0) {
         return $.ajax({
           dataType: "json",
-          url: "/?action=checkentropy&password=" + btoa(newpasswordVal),
+          url: location.pathname + "?action=checkentropy&password=" + btoa(newpasswordVal),
           context: document.body,
           success: function(data) {
             var level, msg;


### PR DESCRIPTION
If you serve SSP behind a reverse proxy that puts it into a certain path, ie `my.domain.tld/ssp/`, entropy checks will result in an error, since it will try to retrieve `my.domain.tld/?action=checkentropy&password=123`. It would be better to use the already known path, ie `my.domain.tld/ssp/index.php?action=change`, since then we already know where the index.php is.

Also, it is not very obvious to the user why checkentropy is not working in that scenario. I had to dig into the developer tools of firefox and see what the response of these failing ajax calls were to find out what is happening.

Closes #830