### PR TITLE
fix warnings for uninitialized variables (#887)

### DIFF
--- a/conf/config.inc.php
+++ b/conf/config.inc.php
@@ -46,6 +46,7 @@ $ldap_fullname_attribute = "cn";
 $ldap_filter = "(&(objectClass=person)($ldap_login_attribute={login}))";
 $ldap_use_exop_passwd = false;
 $ldap_use_ppolicy_control = false;
+$ldap_network_timeout = 10;
 
 # Active Directory mode
 # true: use unicodePwd as password field

--- a/docs/config_ldap.rst
+++ b/docs/config_ldap.rst
@@ -57,6 +57,13 @@ the requirements of your server. For example:
    TLS_CIPHER_SUITE TLSv1+RSA
 
 
+You can also define the ldap connection timeout:
+
+.. code-block:: php
+
+   $ldap_network_timeout = true;
+
+
 Credentials
 -----------
 

--- a/htdocs/index.php
+++ b/htdocs/index.php
@@ -114,12 +114,12 @@ $mailer = new \Ltb\Mail(
 $ldapInstance = new \Ltb\Ldap(
                                  $ldap_url,
                                  $ldap_starttls,
-                                 $ldap_binddn,
-                                 $ldap_bindpw,
-                                 $ldap_network_timeout,
-                                 $ldap_user_base,
-                                 $ldap_size_limit,
-                                 $ldap_krb5ccname
+                                 isset($ldap_binddn) ? $ldap_binddn : null,
+                                 isset($ldap_bindpw) ? $ldap_bindpw : null,
+                                 isset($ldap_network_timeout) ? $ldap_network_timeout : null,
+                                 $ldap_base,
+                                 null,
+                                 isset($ldap_krb5ccname) ? $ldap_krb5ccname : null
                              );
 
 #==============================================================================

--- a/rest/v1/adminchangepassword.php
+++ b/rest/v1/adminchangepassword.php
@@ -24,7 +24,7 @@ if ((isset($_POST["login"]) and $_POST["login"])
 }
 
 # Connect to LDAP
-$ldap_connection = \Ltb\Ldap::connect($ldap_url, $ldap_starttls, $ldap_binddn, $ldap_bindpw, $ldap_network_timeout, $ldap_krb5ccname);
+$ldap_connection = $ldapInstance->connect();
 
 $ldap = $ldap_connection[0];
 $result = $ldap_connection[1];

--- a/rest/v1/changepassword.php
+++ b/rest/v1/changepassword.php
@@ -26,7 +26,7 @@ if ((isset($_POST["login"]) and $_POST["login"])
 }
 
 # Connect to LDAP
-$ldap_connection = \Ltb\Ldap::connect($ldap_url, $ldap_starttls, $ldap_binddn, $ldap_bindpw, $ldap_network_timeout, $ldap_krb5ccname);
+$ldap_connection = $ldapInstance->connect();
 
 $ldap = $ldap_connection[0];
 $result = $ldap_connection[1];

--- a/rest/v1/checkpassword.php
+++ b/rest/v1/checkpassword.php
@@ -16,7 +16,7 @@ if (isset($_POST["login"]) and $_POST["login"]) {
     $login = $_POST["login"];
 
     # Connect to LDAP
-    $ldap_connection = \Ltb\Ldap::connect($ldap_url, $ldap_starttls, $ldap_binddn, $ldap_bindpw, $ldap_network_timeout, $ldap_krb5ccname);
+    $ldap_connection = $ldapInstance->connect();
 
     $ldap = $ldap_connection[0];
     $result = $ldap_connection[1];

--- a/rest/v1/include.php
+++ b/rest/v1/include.php
@@ -93,6 +93,20 @@ $mailer->SMTPOptions   = $mail_smtp_options;
 $mailer->Timeout       = $mail_smtp_timeout;
 
 #==============================================================================
+# LDAP Config
+#==============================================================================
+$ldapInstance = new \Ltb\Ldap(
+                                 $ldap_url,
+                                 $ldap_starttls,
+                                 isset($ldap_binddn) ? $ldap_binddn : null,
+                                 isset($ldap_bindpw) ? $ldap_bindpw : null,
+                                 isset($ldap_network_timeout) ? $ldap_network_timeout : null,
+                                 $ldap_base,
+                                 null,
+                                 isset($ldap_krb5ccname) ? $ldap_krb5ccname : null
+                             );
+
+#==============================================================================
 # Other default values
 #==============================================================================
 if (!isset($ldap_login_attribute)) { $ldap_login_attribute = "uid"; }

--- a/scripts/encrypt_answers.php
+++ b/scripts/encrypt_answers.php
@@ -31,7 +31,7 @@ require_once(__DIR__."/../vendor/autoload.php");
 #==============================================================================
 
 # Connect to LDAP
-$ldap_connection = \Ltb\Ldap::connect($ldap_url, $ldap_starttls, $ldap_binddn, $ldap_bindpw, $ldap_network_timeout, $ldap_krb5ccname);
+$ldap_connection = $ldapInstance->connect();
 
 $ldap = $ldap_connection[0];
 $result = $ldap_connection[1];

--- a/scripts/multi_ldap_change.php
+++ b/scripts/multi_ldap_change.php
@@ -37,13 +37,14 @@ foreach ($secondaries_ldap as $s_ldap) {
     $ldapInstance = new \Ltb\Ldap(
                                      $ldap_url,
                                      $ldap_starttls,
-                                     $ldap_binddn,
-                                     $ldap_bindpw,
-                                     $ldap_network_timeout,
-                                     $ldap_user_base,
-                                     $ldap_size_limit,
-                                     $ldap_krb5ccname
+                                     isset($ldap_binddn) ? $ldap_binddn : null,
+                                     isset($ldap_bindpw) ? $ldap_bindpw : null,
+                                     isset($ldap_network_timeout) ? $ldap_network_timeout : null,
+                                     $ldap_base,
+                                     null,
+                                     isset($ldap_krb5ccname) ? $ldap_krb5ccname : null
                                  );
+
     $ldap_connection = $ldapInstance->connect();
 
     $ldap = $ldap_connection[0];


### PR DESCRIPTION
fix warnings for variables:
$ldap_network_timeout, $ldap_user_base, $ldap_size_limit and $ldap_krb5ccname

also fix instanciation of ldap connection in rest api and scripts

Closes #887