### PR TITLE
Correction of max number of attempts for token sent by sms bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /vendor/
 /htdocs/vendor/
+composer.lock

--- a/conf/config.inc.php
+++ b/conf/config.inc.php
@@ -314,7 +314,7 @@ $sms_truncate_number_length = 10;
 # SMS token length
 $sms_token_length = 6;
 # Max attempts allowed for SMS token
-$max_attempts = 3;
+$sms_max_attempts_token = 3;
 
 # Encryption, decryption keyphrase, required if $use_tokens = true and $crypt_tokens = true, or $use_sms, or $crypt_answer
 # Please change it to anything long, random and complicated, you do not have to remember it

--- a/docs/config_sms.rst
+++ b/docs/config_sms.rst
@@ -173,6 +173,6 @@ You can also configure the allowed attempts:
 
 .. code-block:: php
 
-   $max_attempts = 3;
+   $sms_max_attempts_token = 3;
 
 After these attempts, the sent token is no more valid.

--- a/htdocs/sendsms.php
+++ b/htdocs/sendsms.php
@@ -37,7 +37,6 @@ $token = "";
 $sessiontoken = "";
 $attempts = 0;
 
-
 #==============================================================================
 # Verify minimal information for treatment
 # Encryption needs to be activated
@@ -97,7 +96,8 @@ if (!$crypt_tokens) {
             list($result, $token) = obscure_info_sendsms("tokenattempts","tokennotvalid");
             error_log("Unable to open session $smstokenid");
         } elseif ($sessiontoken != $smstoken) {
-            if ($attempts < $max_attempts) {
+            # To have only x tries and not x+1 tries
+            if ($attempts < ($sms_max_attempts_token - 1)) {
                 $_SESSION['attempts'] = $attempts + 1;
                 $result = "tokenattempts";
                 error_log("SMS token $smstoken not valid, attempt $attempts");
@@ -196,11 +196,10 @@ if ($result === "sendsms") {
 
     $data = array( "sms_attribute" => $sms, "smsresetmessage" => $messages['smsresetmessage'], "smstoken" => $smstoken) ;
 
-    # Send message
+    # The default sms method is mail
     if (!$sms_method) { $sms_method = "mail"; }
 
     if ($sms_method === "mail") {
-
         if ($mailer->send_mail($smsmailto, $mail_from, $mail_from_name, $smsmail_subject, $sms_message, $data)) {
             $token  = encrypt(session_id(), $keyphrase);
             $result = "smssent";


### PR DESCRIPTION
Added more explicit variable name and correcting number of token tries.

Closes #861 