### PR TITLE
Corrected error introduced when adding obscure notifications

### DIFF
--- a/htdocs/sendsms.php
+++ b/htdocs/sendsms.php
@@ -129,7 +129,7 @@ if (!$crypt_tokens) {
     } elseif (isset($_REQUEST["encrypted_sms_login"])) {
         $decrypted_sms_login = explode(':', decrypt($_REQUEST["encrypted_sms_login"], $keyphrase));
         $login = $decrypted_sms_login[1];
-        [$result, $phone] = get_mobile_and_displayname(
+        [$result, $sms] = get_mobile_and_displayname(
                                     $ldapInstance, $ldap_base, $ldap_filter,
                                     $ldap_fullname_attribute, $sms_attributes,
                                     $sms_sanitize_number, $sms_truncate_number,


### PR DESCRIPTION
An error was introduced by commit 0ab603b0566132e8bbb234d2df908ffe03a5f1f4 
when adding the obscure option for notifications.
Using ldap for sms (sms_use_ldap=true) did not worked anymore.

Now it is corrected.