### PR TITLE
remove smarty messages in error logs unless $smarty_debug is set to true (#909)

### DIFF
--- a/conf/config.inc.php
+++ b/conf/config.inc.php
@@ -430,6 +430,7 @@ $obscure_notfound_sendsms = true;
 #$smarty_cache_dir = "/var/cache/self-service-password/cache";
 
 # Smarty debug mode - will popup debug information on web interface
+# and add many smarty debug messages in error logs
 $smarty_debug = false;
 
 ## Custom Password Fields

--- a/docs/config_general.rst
+++ b/docs/config_general.rst
@@ -189,7 +189,8 @@ This is also possible to enable Smarty debug, for web interface issues:
 
    $smarty_debug = true;
 
-.. tip:: Debug messages will appear on web interface.
+.. tip:: Debug messages will appear on web interface as a popup.
+   You will also have many more messages in error logs.
 
 .. _security:
 

--- a/htdocs/index.php
+++ b/htdocs/index.php
@@ -223,6 +223,15 @@ $smarty->setTemplateDir('../templates/');
 $smarty->setCompileDir($compile_dir);
 $smarty->setCacheDir($cache_dir);
 $smarty->debugging = $smarty_debug;
+if(isset($smarty_debug) && $smarty_debug == true )
+{
+    $smarty->error_reporting = E_ALL;
+}
+else
+{
+    # Do not report smarty stuff unless $smarty_debug == true
+    $smarty->error_reporting = E_ALL & ~E_NOTICE & ~E_STRICT & ~E_DEPRECATED & ~E_WARNING;
+}
 
 # Assign configuration variables
 $smarty->assign('ldap_params',array('ldap_url' => $ldap_url, 'ldap_starttls' => $ldap_starttls, 'ldap_binddn' => $ldap_binddn, 'ldap_bindpw' => $ldap_bindpw));


### PR DESCRIPTION
Closes #909 