### PR TITLE
Use Alpine-PHP Image to Reduce Security Issues

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,4 +6,4 @@ then
   cp -a -f /var/www/config.inc.php.orig /var/www/conf/config.inc.php
 fi
 
-apache2-foreground
+httpd -DFOREGROUND

--- a/packaging/README
+++ b/packaging/README
@@ -1,17 +1,20 @@
-#==============================================================================
 # Some notes on packaging Self Service Password
-#==============================================================================
 
-# 0 - Version update
-#==============================================================================
+ #==============================================================================
+
+## 0 - Version update
+
+ #==============================================================================
 
 Update version in following files:
+
 * htdocs/index.php
 * packaging/rpm/SPECS/self-service-password.spec
 * packaging/debian/changelog
 
-# 1 - Update dependencies and run tests
-#==============================================================================
+## 1 - Update dependencies and run tests
+
+ #==============================================================================
 
 From the self-service-password root directory, run:
 $ composer update
@@ -22,21 +25,21 @@ $ XDEBUG_MODE=coverage vendor/bin/phpunit --coverage-text --configuration tests/
 After the tests, remove the useless dependencies:
 $ composer update --no-dev
 
+## 2 - Archive tar.gz
 
-# 2 - Archive tar.gz
-#==============================================================================
+ #==============================================================================
 
 From current directory, do:
-$ ./makedist VERSION
+$ ./makedist.sh VERSION
 
 with VERSION the current verion of the package
 
 For example:
-$ ./makedist 0.4
+$ ./makedist.sh 0.4
 
+## 3 - Debian
 
-# 3 - Debian
-#==============================================================================
+ #==============================================================================
 
 Form current directory, do:
 $ dpkg-buildpackage -b -kLTB
@@ -44,13 +47,15 @@ $ dpkg-buildpackage -b -kLTB
 If you do not have LTB GPG secret key, do:
 $ dpkg-buildpackage -b -us -uc
 
-# 4 - RPM (RHEL, CentOS, Fedora, ...)
-#==============================================================================
+## 4 - RPM (RHEL, CentOS, Fedora, ...)
+
+ #==============================================================================
 
 Prepare your build environment, for example in /home/clement/build.
 You should have a ~/.rpmmacros like this:
 
 ----
+
 %_topdir /home/clement/build
 %dist .el5
 %distribution .el5
@@ -74,8 +79,9 @@ $ rpmbuild -ba SPECS/self-service-password.spec
 Sign RPM:
 $ rpm --addsign RPMS/noarch/self-service-password*
 
-# 5 - Docker
-#==============================================================================
+## 5 - Docker
+
+ #==============================================================================
 
 From current directory, do:
 $ docker build -t self-service-password -f ./docker/Dockerfile ../

--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -34,7 +34,7 @@ LABEL org.opencontainers.image.authors='LTB-project.org, ltb-dev@ow2.org' \
       org.opencontainers.image.version='1.6.0' \
       org.opencontainers.image.licenses='GPL-2+'
 
-RUN apk update && apk add $BUILDDEP --no-cache \
+RUN apk add $BUILDDEP --no-cache \
     && docker-php-ext-install bcmath bz2 intl mbstring opcache curl \
     && docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp \
     && docker-php-ext-install ldap gd \

--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -1,6 +1,7 @@
 FROM php:8.2-fpm-alpine
 
 ENV BUILDDEP=" \
+        php-apache2 \
         php-ldap \
         php-gd \
         bash \
@@ -52,5 +53,5 @@ ENV COMPOSER_ALLOW_SUPERUSER=1
 RUN cd /var/www && /usr/bin/composer install
 ENV LC_CTYPE=en_US.UTF-8
 EXPOSE 80
-RUN cp -a -f /var/www/config.inc.php.orig /var/www/conf/config.inc.php
+RUN sed -i 's|/var/www/localhost/htdocs|/var/www/html|g' /etc/apache2/httpd.conf
 ENTRYPOINT ["/var/www/entrypoint.sh"]

--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -1,19 +1,25 @@
-FROM php:8.2-apache
-# Install PHP extensions and PECL modules.
+FROM php:8.2-fpm-alpine
+
 ENV BUILDDEP=" \
-        libbz2-dev \
-        libsasl2-dev \
-        libcurl4-gnutls-dev \
-	libfreetype6-dev \
-	libpng-dev \
-	libjpeg62-turbo-dev \
-	libwebp-dev \
-        libonig-dev \
-        git \
-        zip \
+        php-ldap \
+        php-gd \
+        bash \
+        bzip2-dev \
+        icu-dev \
+        oniguruma-dev \
+        libldap \
+        openldap-dev \
+        curl \
+        curl-dev \
+        libpng-dev \
+        libwebp-dev \
+        libjpeg-turbo-dev \
+        freetype-dev \
+        openrc \
+        apache2 \
     "
 LABEL org.opencontainers.image.authors='LTB-project.org, ltb-dev@ow2.org' \
-      org.opencontainers.image.base.name='docker.io/library/php:8.2-apache' \
+      org.opencontainers.image.base.name='docker.io/library/php:8.2-fpm-alpine' \
       org.opencontainers.image.description='Self Service Password is a simple PHP application that allows users to change their password on an LDAP directory' \
       org.opencontainers.image.url='https://ltb-project.org/documentation/self-service-password.html' \
       org.opencontainers.image.ref.name='self-service-password' \
@@ -24,29 +30,12 @@ LABEL org.opencontainers.image.authors='LTB-project.org, ltb-dev@ow2.org' \
       org.opencontainers.image.version='1.6.0' \
       org.opencontainers.image.licenses='GPL-2+'
 
-RUN buildDeps="${BUILDDEP}" \
-    runtimeDeps=" \
-        curl \
-        libicu-dev \
-        libldap-common \
-        libldap2-dev \
-	libgd3 \
-	libjpeg62-turbo \
-	libpng16-16 \
-	libwebp7 \
-        libzip-dev \
-	locales \
-	locales-all \
-	sendmail \
-    " \
-    && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y $buildDeps $runtimeDeps \
-    && docker-php-ext-install bcmath bz2 iconv intl mbstring opcache curl \
-    && docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp \
-    && docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ \
+RUN apk update && apk add $BUILDDEP --no-cache \
+    && docker-php-ext-install bcmath bz2 intl mbstring opcache curl \
     && docker-php-ext-install ldap gd \
-    && echo en_US.UTF-8 UTF-8 >/etc/locale.gen \
-    && /usr/sbin/locale-gen \
-    && a2enmod rewrite
+    && docker-php-ext-enable ldap gd
+
+
 RUN mkdir -p /usr/share/php/smarty4/ && \
     curl -Lqs https://github.com/smarty-php/smarty/archive/refs/tags/v4.4.1.tar.gz | \
     tar xzf - -C /usr/share/php/smarty4/ --strip-components=2
@@ -59,10 +48,10 @@ RUN rmdir /var/www/html && \
     sed -i 's/smarty3/smarty4/' /var/www/conf/config.inc.php && \
     cp -a /var/www/conf/config.inc.php /var/www/config.inc.php.orig
 COPY --from=composer/composer:latest-bin /composer /usr/bin/composer
+ENV COMPOSER_ALLOW_SUPERUSER=1
 RUN cd /var/www && /usr/bin/composer install
-RUN buildDeps="${BUILDDEP}" \
-    && apt-get purge -y --auto-remove $buildDeps \
-    && rm -r /var/lib/apt/lists/*
 ENV LC_CTYPE=en_US.UTF-8
 EXPOSE 80
-CMD ["/var/www/entrypoint.sh"]
+RUN cp -a -f /var/www/config.inc.php.orig /var/www/conf/config.inc.php
+ENTRYPOINT ["/usr/sbin/httpd", "-D", "FOREGROUND"]
+#TODO ajust the ENTRYPOINT.sh

--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -53,5 +53,4 @@ RUN cd /var/www && /usr/bin/composer install
 ENV LC_CTYPE=en_US.UTF-8
 EXPOSE 80
 RUN cp -a -f /var/www/config.inc.php.orig /var/www/conf/config.inc.php
-ENTRYPOINT ["/usr/sbin/httpd", "-D", "FOREGROUND"]
-#TODO ajust the ENTRYPOINT.sh
+ENTRYPOINT ["/var/www/entrypoint.sh"]

--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -42,8 +42,9 @@ RUN apk add $BUILDDEP --no-cache \
 
 RUN mkdir -p /usr/share/php/smarty4/ && \
     curl -Lqs https://github.com/smarty-php/smarty/archive/refs/tags/v4.4.1.tar.gz | \
-    tar xzf - -C /usr/share/php/smarty4/ --strip-components=2
-RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
+    tar xzf - -C /usr/share/php/smarty4/ --strip-components=2 \
+    mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
+
 COPY . /var/www
 RUN rmdir /var/www/html && \
     mv /var/www/htdocs /var/www/html && \

--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -4,6 +4,8 @@ ENV BUILDDEP=" \
         php-apache2 \
         php-ldap \
         php-gd \
+        php-iconv \
+        php-mbstring \
         bash \
         bzip2-dev \
         icu-dev \
@@ -18,6 +20,7 @@ ENV BUILDDEP=" \
         freetype-dev \
         openrc \
         apache2 \
+        ca-certificates \
     "
 LABEL org.opencontainers.image.authors='LTB-project.org, ltb-dev@ow2.org' \
       org.opencontainers.image.base.name='docker.io/library/php:8.2-fpm-alpine' \
@@ -33,9 +36,9 @@ LABEL org.opencontainers.image.authors='LTB-project.org, ltb-dev@ow2.org' \
 
 RUN apk update && apk add $BUILDDEP --no-cache \
     && docker-php-ext-install bcmath bz2 intl mbstring opcache curl \
+    && docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp \
     && docker-php-ext-install ldap gd \
     && docker-php-ext-enable ldap gd
-
 
 RUN mkdir -p /usr/share/php/smarty4/ && \
     curl -Lqs https://github.com/smarty-php/smarty/archive/refs/tags/v4.4.1.tar.gz | \

--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -42,8 +42,9 @@ RUN apk add $BUILDDEP --no-cache \
 
 RUN mkdir -p /usr/share/php/smarty4/ && \
     curl -Lqs https://github.com/smarty-php/smarty/archive/refs/tags/v4.4.1.tar.gz | \
-    tar xzf - -C /usr/share/php/smarty4/ --strip-components=2 \
-    mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
+    tar xzf - -C /usr/share/php/smarty4/ --strip-components=2
+
+RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
 
 COPY . /var/www
 RUN rmdir /var/www/html && \

--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -45,7 +45,7 @@ COPY . /var/www
 RUN rmdir /var/www/html && \
     mv /var/www/htdocs /var/www/html && \
     mkdir -p /var/www/templates_c && \
-    chown -R www-data: /var/www/templates_c && \
+    chown -R apache: /var/www/templates_c && \
     sed -i 's/smarty3/smarty4/' /var/www/conf/config.inc.php && \
     cp -a /var/www/conf/config.inc.php /var/www/config.inc.php.orig
 COPY --from=composer/composer:latest-bin /composer /usr/bin/composer


### PR DESCRIPTION
Change the Base Image of the Service to alpine because Debian, is using unnecessary features.

This has the effect: 

Container Security Scan (trivy):

* Old Base Image: Total: 1992 (UNKNOWN: 20, LOW: 634, MEDIUM: 1142, HIGH: 190, CRITICAL: 6)
* New Base Image: Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)

Size:
* Old Image: 1.11GB
* New Image: 324MB

Fixes #925