### PR TITLE
Making it possible to docker build both on M1/M2/M3 Mac and in an x86 VM

### DIFF
--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -59,7 +59,7 @@ RUN --mount=type=cache,target=/var/lib/apt/lists \
     \
     docker-php-source extract; \
     docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp; \
-    docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/; \
+    docker-php-ext-configure ldap --with-libdir=lib/$(uname -m)-linux-gnu/; \
     docker-php-ext-install -j "$(nproc)" \
         bcmath \
         bz2 \


### PR DESCRIPTION
Simple fix to make it possible to build on Mac as well as on x86.