### PR TITLE
Only call ldap_get_dn on an entry

### DIFF
--- a/scripts/multi_ldap_change.php
+++ b/scripts/multi_ldap_change.php
@@ -76,7 +76,10 @@ foreach ($secondaries_ldap as $s_ldap) {
 
     # Get user DN
     $entry = ldap_first_entry($ldap, $search);
-    $userdn = ldap_get_dn($ldap, $entry);
+    $userdn = null;
+    if ( $entry ) {
+        $userdn = ldap_get_dn($ldap, $entry);
+    }
 
     if( !$userdn ) {
         $result = "badcredentials";


### PR DESCRIPTION
This prevents a fatal error in scripts/multi_ldap_change.php

Fix for #970 