### PR TITLE
Fix input-group on sendtoken (mail) page

### DIFF
--- a/templates/sendtoken.tpl
+++ b/templates/sendtoken.tpl
@@ -20,8 +20,8 @@
             <div class="input-group">
                 <span class="input-group-text"><i class="fa fa-fw fa-user"></i></span>
                 <input type="text" name="login" id="login" value="{$login}" class="form-control" placeholder="{$msg_login}" autocomplete="off" />
-                <input type="hidden" name="formtoken" id="formtoken" value="{$formtoken}" />
             </div>
+            <input type="hidden" name="formtoken" id="formtoken" value="{$formtoken}" />
         </div>
     </div>
     {if !$mail_address_use_ldap}


### PR DESCRIPTION
Moved the hidden token input outside the Bootstrap input-group to ensure the correct display of the border-radius at the end of the text input