### PR TITLE
Allow customized template

### DIFF
--- a/conf/config.inc.php
+++ b/conf/config.inc.php
@@ -406,6 +406,9 @@ $background_image = "images/unsplash-space.jpeg";
 $custom_css = "";
 $display_footer = true;
 
+# Customized template directory: to ovverride some templates files
+$custom_tpl_dir = "";
+
 # Where to log password resets - Make sure apache has write permission
 # By default, they are logged in Apache log
 #$reset_request_log = "/var/log/self-service-password";

--- a/docs/config_general.rst
+++ b/docs/config_general.rst
@@ -174,6 +174,17 @@ You can hide the footer bar:
 
     $display_footer = false;
 
+Custom templates
+^^^^^^^^^^^^^^^^
+
+If you need to do more changes on the interface, you can create a custom templates directory
+and override any of template file by copying it from ``templates/`` into the custom directory
+and adapt it to your needs:
+
+.. code-block:: php
+
+    $custom_tpl_dir = "templates_custom/";
+
 Debug
 -----
 

--- a/htdocs/index.php
+++ b/htdocs/index.php
@@ -256,10 +256,11 @@ require_once(SMARTY);
 
 $compile_dir = isset($smarty_compile_dir) ? $smarty_compile_dir : "../templates_c/";
 $cache_dir = isset($smarty_cache_dir) ? $smarty_cache_dir : "../cache/";
+$tpl_dir = isset($custom_tpl_dir) ? array('../'.$custom_tpl_dir, '../templates/') : '../templates/';
 
 $smarty = new Smarty();
 $smarty->escape_html = true;
-$smarty->setTemplateDir('../templates/');
+$smarty->setTemplateDir($tpl_dir);
 $smarty->setCompileDir($compile_dir);
 $smarty->setCacheDir($cache_dir);
 $smarty->debugging = $smarty_debug;


### PR DESCRIPTION
This adds the `$custom_tpl_dir` option in configuration which can be used to create a customized template.

You can just override one or two templates files by copying them to the custom template directory and adapt them.