### PR TITLE
Add show password eye on each password input to show/hide passwords

### DIFF
--- a/conf/config.inc.php
+++ b/conf/config.inc.php
@@ -396,6 +396,9 @@ $allowed_lang = array();
 # Display menu on top
 $show_menu = true;
 
+# Display eyes to show password fields
+$show_pwd_eyes = false;
+
 # Logo
 $logo = "images/ltb-logo.png";
 

--- a/htdocs/css/self-service-password.css
+++ b/htdocs/css/self-service-password.css
@@ -66,6 +66,11 @@ textarea#sshkey {
 
 }
 
+.form-control {
+  border-top-right-radius: var(--bs-border-radius) !important;
+  border-bottom-right-radius: var(--bs-border-radius) !important;
+}
+
 .password-toggle-icon {
   position: absolute;
   top: 50%;

--- a/htdocs/css/self-service-password.css
+++ b/htdocs/css/self-service-password.css
@@ -65,3 +65,19 @@ textarea#sshkey {
   }
 
 }
+
+.password-toggle-icon {
+  position: absolute;
+  top: 50%;
+  right: 10px;
+  transform: translateY(-50%);
+  cursor: pointer;
+  z-index: 999;
+}
+
+.password-toggle-icon i {
+  font-size: 18px;
+  line-height: 1;
+  color: black;
+  transition: color 0.3s ease-in-out;
+}

--- a/htdocs/index.php
+++ b/htdocs/index.php
@@ -282,6 +282,7 @@ $smarty->assign('version',$version);
 $smarty->assign('display_footer',$display_footer);
 $smarty->assign('show_menu', $show_menu);
 $smarty->assign('show_help', $show_help);
+$smarty->assign('show_pwd_eyes', $show_pwd_eyes);
 $smarty->assign('use_questions', $use_questions);
 $smarty->assign('use_tokens', $use_tokens);
 $smarty->assign('use_sms', $use_sms);

--- a/htdocs/js/show-password-input.js
+++ b/htdocs/js/show-password-input.js
@@ -1,0 +1,17 @@
+const fields = ["oldpassword", "newpassword", "confirmpassword"];
+fields.map((field) => {
+    const passwordField = document.getElementById(field);
+    const togglePassword = passwordField.parentElement.querySelector(".password-toggle-icon i");
+
+    togglePassword.addEventListener("click", () => {
+        if (passwordField.type === "password") {
+            passwordField.type = "text";
+            togglePassword.classList.remove("fa-eye");
+            togglePassword.classList.add("fa-eye-slash");
+        } else {
+            passwordField.type = "password";
+            togglePassword.classList.remove("fa-eye-slash");
+            togglePassword.classList.add("fa-eye");
+        }
+    });
+})

--- a/templates/change.tpl
+++ b/templates/change.tpl
@@ -53,7 +53,9 @@
                 <div class="input-group">
                     <span class="input-group-text"><i class="fa fa-fw fa-lock"></i></span>
                     <input type="password" autocomplete="current-password" name="oldpassword" id="oldpassword" class="form-control" placeholder="{$msg_oldpassword}" />
-                    <span class="password-toggle-icon"><i class="fas fa-eye"></i></span>
+                    {if $show_pwd_eyes}
+                        <span class="password-toggle-icon"><i class="fas fa-eye"></i></span>
+                    {/if}
                 </div>
             </div>
         </div>
@@ -63,7 +65,9 @@
                 <div class="input-group">
                     <span class="input-group-text"><i class="fa fa-fw fa-lock"></i></span>
                     <input type="password" autocomplete="new-password" name="newpassword" id="newpassword" class="form-control" placeholder="{$msg_newpassword}" />
-                    <span class="password-toggle-icon"><i class="fas fa-eye"></i></span>
+                    {if $show_pwd_eyes}
+                        <span class="password-toggle-icon"><i class="fas fa-eye"></i></span>
+                    {/if}
                 </div>
             </div>
         </div>
@@ -73,7 +77,9 @@
                 <div class="input-group">
                     <span class="input-group-text"><i class="fa fa-fw fa-lock"></i></span>
                     <input type="password" autocomplete="new-password" name="confirmpassword" id="confirmpassword" class="form-control" placeholder="{$msg_confirmpassword}" />
-                    <span class="password-toggle-icon"><i class="fas fa-eye"></i></span>
+                    {if $show_pwd_eyes}
+                        <span class="password-toggle-icon"><i class="fas fa-eye"></i></span>
+                    {/if}
                 </div>
             </div>
         </div>
@@ -97,4 +103,6 @@
     <i class="fa fa-fw {$result_fa_class}" aria-hidden="true"></i> {$msg_passwordchangedextramessage|unescape: "html" nofilter}
     </div>
 {/if}
-<script src="js/show-password-input.js"></script>
+{if $show_pwd_eyes}
+    <script src="js/show-password-input.js"></script>
+{/if}

--- a/templates/change.tpl
+++ b/templates/change.tpl
@@ -53,6 +53,7 @@
                 <div class="input-group">
                     <span class="input-group-text"><i class="fa fa-fw fa-lock"></i></span>
                     <input type="password" autocomplete="current-password" name="oldpassword" id="oldpassword" class="form-control" placeholder="{$msg_oldpassword}" />
+                    <span class="password-toggle-icon"><i class="fas fa-eye"></i></span>
                 </div>
             </div>
         </div>
@@ -62,6 +63,7 @@
                 <div class="input-group">
                     <span class="input-group-text"><i class="fa fa-fw fa-lock"></i></span>
                     <input type="password" autocomplete="new-password" name="newpassword" id="newpassword" class="form-control" placeholder="{$msg_newpassword}" />
+                    <span class="password-toggle-icon"><i class="fas fa-eye"></i></span>
                 </div>
             </div>
         </div>
@@ -71,6 +73,7 @@
                 <div class="input-group">
                     <span class="input-group-text"><i class="fa fa-fw fa-lock"></i></span>
                     <input type="password" autocomplete="new-password" name="confirmpassword" id="confirmpassword" class="form-control" placeholder="{$msg_confirmpassword}" />
+                    <span class="password-toggle-icon"><i class="fas fa-eye"></i></span>
                 </div>
             </div>
         </div>
@@ -94,3 +97,4 @@
     <i class="fa fa-fw {$result_fa_class}" aria-hidden="true"></i> {$msg_passwordchangedextramessage|unescape: "html" nofilter}
     </div>
 {/if}
+<script src="js/show-password-input.js"></script>


### PR DESCRIPTION
Added an eye icon on each password input to hide/show passwords.
Added `js/show-password.js` javascript file to be included in `templates/change.tpl` template.
Added `.password-toggle-icon` and `.password-toggle-icon i` in `css/self-service-password.css`.