### PR TITLE
Fix validation of SSH public keys

### DIFF
--- a/lib/functions.inc.php
+++ b/lib/functions.inc.php
@@ -186,8 +186,8 @@ function check_sshkey ( $sshkey, $valid_types ) {
             return false;
         }
 
-        $ealg = base64_encode($algorithm . " AAAA");
-        $check = preg_replace('/[\x00-\x1F\x7F]/u', '', base64_decode(substr($key, 0, strlen($ealg))));
+        $raw_key = base64_decode($key);
+        $check = substr($raw_key, 4, strlen($algorithm));
         if ((string) $check !== (string) $algorithm) {
             return false;
         }


### PR DESCRIPTION
I found a bug in `check_sshkey`. Key using algorithms with long names (longer than 0x1F characters) get incorrectly rejected.
One example for such an algorithm is `sk-ecdsa-sha2-nistp256@openssh.com` (0x22 characters). This results in an extra `"` in `$check`, which then obviously does not match `$algorithm`.

The first four bytes of the decoded public key specify the length of the following algorithm name.
`preg_replace` removes these four bytes *if* they are in the non-printable range. Otherwise some of the length bytes end up in `$check`.

This PR fixes this by always discarding the first four bytes and comparing the expected number of bytes.