### PR TITLE
Fix handling of multi-word comments in SSH keys

### DIFF
--- a/lib/functions.inc.php
+++ b/lib/functions.inc.php
@@ -169,9 +169,6 @@ function check_sshkey ( $sshkey, $valid_types ) {
         if (count($key_parts) < 2) {
             return false;
         }
-        if (count($key_parts) > 3) {
-            return false;
-        }
 
         $algorithm = $key_parts[0];
         if (count($valid_types) > 0) {


### PR DESCRIPTION
`check_sshkey` splits the input on spaces and checks that there are at least two and at most three parts. This work well for the customary `user@host` comments. However, comments may contain spaces, which `check_sshkey` incorrectly rejects.

As there is no upper limit on the number of space-separated "parts" a key may have, I simply remove the check.
The more elaborate checks that follow should be sufficient to catch copy & paste errors.