### PR TITLE
Update config.inc.php smarty Version

### DIFF
--- a/conf/config.inc.php
+++ b/conf/config.inc.php
@@ -508,7 +508,7 @@ if (file_exists (__DIR__ . '/config.inc.local.php')) {
 
 # Smarty
 if (!defined("SMARTY")) {
-    define("SMARTY", "/usr/share/php/smarty3/Smarty.class.php");
+    define("SMARTY", "/usr/share/php/smarty4/Smarty.class.php");
 }
 
 # Set preset login from HTTP header $header_name_preset_login


### PR DESCRIPTION
Im using the docker image, but even in the repo there is this line: https://github.com/ltb-project/self-service-password/blob/ae18dc85a793f927b591bc255138a775ce9e8765/conf/config.inc.php#L511

Why does it refer to smarty3? I dont know for manual installs or via apt repo, but in the docker image only /usr/share/php/smarty4/ exists. Which makes sense since in https://github.com/ltb-project/self-service-password/blob/ae18dc85a793f927b591bc255138a775ce9e8765/packaging/docker/Dockerfile#L3 smarty4 gets installed.

Changing the line to /usr/share/php/smarty4/Smarty.class.php also makes the container work instead of throwing a HTTP 500.