### PR TITLE
Fix call of change_password function insed multi-ldap-change script

### DIFF
--- a/scripts/multi_ldap_change.php
+++ b/scripts/multi_ldap_change.php
@@ -143,7 +143,7 @@ foreach ($secondaries_ldap as $s_ldap) {
         # Change password
         #==============================================================================
         if ( !$result ) {
-            $result = change_password( $directory, $ldapInstance, $userdn, $newpassword, $ldap_options, $samba_mode, $samba_options, $shadow_options, $hash, $hash_options, 'manager', $oldpassword, $ldap_use_exop_passwd, $ldap_use_ppolicy_control, false, "");
+            $result = change_password( $s_directory, $ldapInstance, $userdn, $newpassword, $ldap_options, $samba_mode, $samba_options, $shadow_options, $hash, $hash_options, 'manager', $oldpassword, $ldap_use_exop_passwd, $ldap_use_ppolicy_control, false, "");
             if ( $result !== "passwordchanged" ) {
                 fwrite($log_file, "Change on $s_ldap_url: KO\n");
             } else {


### PR DESCRIPTION
$directory is undefined in the foreach scope, causing a fatal error when change_password() is called. The correct local variable is $s_directory, initialized by the switch($s_ldap_type) block above.